### PR TITLE
Map simplifications

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -167,6 +167,7 @@ input:focus#languagefilter {
 }
 
 #search{
+	position: relative;
 	background: #f8f8f8;
 	background: linear-gradient(#F0F0F0, #FBFBFB);
 	background: -webkit-gradient(linear, left top, left bottom, from(#F0F0F0), to(#FBFBFB));


### PR DESCRIPTION
The map has been simplified by:
- Reducing the thickness of the the current region indicators.
- Making labels invisible until the user access them.

Initial tests show that no problems are introduced, so we win in simplicity with these changes. 
The 2nd change is really easy to revert if we found problems with users discovering map interactivity after deployment.
