### PR TITLE
CSS fix to avoid style clash with link color on map labels

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -119,16 +119,18 @@ div.uls-region {
 	float: right;
 	overflow: hidden;
 	opacity: 0.7;
-	transition: opacity 0.2s linear;
 	-moz-transition: opacity 0.2s linear;
+	-o-transition: opacity 0.2s linear;
 	-webkit-transition: opacity 0.2s linear;
+	transition: opacity 0.2s linear;
 }
 
 #map-block a {
 	opacity:0;
-	transition: opacity 0.15s linear;
 	-moz-transition: opacity 0.15s linear;
+	-o-transition: opacity 0.15s linear;
 	-webkit-transition: opacity 0.15s linear;
+	transition: opacity 0.15s linear;
 }
 
 #map-block:hover, #map-block:hover a {
@@ -159,12 +161,16 @@ div.uls-region {
 
 input#languagefilter {
 	border: 1px solid #c9c9c9;
-	-moz-transition: all 0.15s linear 0s;
 	border-radius: 2px 2px 2px 2px;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) inset;
 	color: #333;
 	display: block;
 	background-color: transparent !important;
+	-moz-transition: all 0.15s linear 0s;
+	-o-transition: all 0.15s linear 0s;
+	-webkit-transition: all 0.15s linear 0s;
+	transition: all 0.15s linear 0s;
+
 }
 
 input:focus#languagefilter {


### PR DESCRIPTION
Map labels are shown as blue when the ULS is integrated with MediaWiki.
This commit:
- Changes the hidding label strategy to be based on modifying the opacity (not the color of links).
- Specifis the label color explicitly to avoid CSS conflicts.
