### PR TITLE
Cleanup/2012/11/16

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -211,7 +211,7 @@
 			// Register all event listeners to the ULS here.
 			uls.$element.on( 'click', $.proxy( uls.click, uls ) );
 
-			uls.$languageFilter.on( 'seachclear', $.proxy( uls.defaultSearch, uls ) );
+			uls.$languageFilter.on( 'searchclear', $.proxy( uls.defaultSearch, uls ) );
 			// Handle click on close button
 			uls.$menu.find( '#uls-close' ).on( 'click', $.proxy( uls.cancel, uls ) );
 

--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -117,7 +117,7 @@
 		 */
 		clear: function() {
 			this.deactivate();
-			this.$element.trigger( 'seachclear' );
+			this.$element.trigger( 'searchclear' );
 		},
 
 		/**


### PR DESCRIPTION
Mostly cosmetic cleanup:
- Whitespace, quotes.
- Renamed a misspelled event.
- Renamed 'that' to 'uls'.
