### PR TITLE
Avoid transition for all properties of search bar

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -173,10 +173,10 @@ div.uls-region {
 	color: #333;
 	display: block;
 	padding: 6px;
-	-moz-transition: all 0.15s linear 0s;
-	-o-transition: all 0.15s linear 0s;
-	-webkit-transition: all 0.15s linear 0s;
-	transition: all 0.15s linear 0s;
+	-moz-transition: border 0.15s linear 0s;
+	-o-transition: border 0.15s linear 0s;
+	-webkit-transition: border 0.15s linear 0s;
+	transition: border 0.15s linear 0s;
 }
 
 .uls-menu .languagefilter:focus {


### PR DESCRIPTION
Transition property has been adjusted for the search bar to affect only the border.
Initially it was set to all when only the border changes.
Apart of efficiency reasons, when zooming a glitch was produced.
