### PR TITLE
Cursor adjustment for regions in the 'no found' view

### DIFF
--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -86,3 +86,7 @@
 	-moz-border-radius:  0 0 5px 5px;
 	border-radius:  0 0 5px 5px;
 }
+
+.uls-no-found-more a {
+	cursor: pointer;
+}


### PR DESCRIPTION
Sets the cursor type to pointer so that the regions at the bottom
of the 'no found' view act as links (hand cursor is ahown on hover).
