### PR TITLE
Exclude .project file from Git sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 /dist
 data/supplementalData.xml
+.project


### PR DESCRIPTION
Added ".project" to git-ignore to avoid sync of Eclipse project metadata
