### PR TITLE
Fix to remove back link underline on compact mode

### DIFF
--- a/css/jquery.uls.compact.css
+++ b/css/jquery.uls.compact.css
@@ -49,6 +49,7 @@
 	margin: 15px 0 5px 19px;
 	cursor: pointer;
 	padding: 6px;
+	text-decoration: none;
 	font-size: 14px;
 	border: 1px solid transparent;
 }


### PR DESCRIPTION
Rule to avoid the back link to be underlined when it is rendered as
a button for the compact version of ULS.
