### PR TITLE
Small CSS adjustments for compact mode

### DIFF
--- a/css/jquery.uls.compact.css
+++ b/css/jquery.uls.compact.css
@@ -24,6 +24,7 @@
 	box-shadow: none;
 	outline: none;
 	font-size: 18px;
+	left: 0;
 }
 
 .uls-compact .uls-language-list {
@@ -49,6 +50,7 @@
 	margin: 15px 0 5px 19px;
 	cursor: pointer;
 	padding: 6px;
+	text-decoration: none;
 	font-size: 14px;
 	border: 1px solid transparent;
 }


### PR DESCRIPTION
A couple of fixes:
- Rule to avoid the back link to be underlined when it is rendered as
  a button for the compact version of ULS.
- Fix for a 1px misalignment between search box and suggestion (the
  1px is needed only when search box has a 1px border)
