### PR TITLE
Add an onVisible hook

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -114,23 +114,27 @@
 	ULS.prototype = {
 		constructor: ULS,
 
-		// A "hook" that runs after the ULS constructor.
-		// At this point it is not guaranteed that the ULS has its dimensions
-		// and that the languages lists are initialized.
-		//
-		// To use it, pass a function as the onReady parameter
-		// in the options when initializing ULS.
+		/**
+		 * A "hook" that runs after the ULS constructor.
+		 * At this point it is not guaranteed that the ULS has its dimensions
+		 * and that the languages lists are initialized.
+		 *
+		 * To use it, pass a function as the onReady parameter
+		 * in the options when initializing ULS.
+		 */
 		ready: function () {
 			if ( this.options.onReady ) {
 				this.options.onReady.call( this );
 			}
 		},
 
-		// A "hook" that runs after the ULS panel becomes visible
-		// by using the show method.
-		//
-		// To use it, pass a function as the onVisible parameter
-		// in the options when initializing ULS.
+		/**
+		 * A "hook" that runs after the ULS panel becomes visible
+		 * by using the show method.
+		 *
+		 * To use it, pass a function as the onVisible parameter
+		 * in the options when initializing ULS.
+		 */
 		visible: function () {
 			if ( this.options.onVisible ) {
 				this.options.onVisible.call( this );


### PR DESCRIPTION
A hook that can optionally run after the ULS menu is shown.
There are things that cannot be done in ready(), because
the style may not have been initialized yet.
