### PR TITLE
RegionSelector: Scroll to appropriate area instead of rebuilding the list

### DIFF
--- a/src/jquery.uls.regionfilter.js
+++ b/src/jquery.uls.regionfilter.js
@@ -35,7 +35,7 @@
 		this.options = $.extend( {}, $.fn.regionselector.defaults, options );
 		this.$element.addClass( 'regionselector' );
 		this.regions = [];
-		this.cache= null;
+		this.cache = null;
 		this.regionGroup = this.$element.data( 'regiongroup' );
 		this.init();
 		this.listen();
@@ -149,9 +149,12 @@
 				return;
 			}
 
-			// Re-populate the list of languages
-			this.options.$target.empty();
-			this.show();
+			// Scroll to appropriate area
+			this.options.$target.$element
+				.find( '#' + this.regions[0] )
+				.get( 0 )
+				.scrollIntoView( true, { behavior: 'smooth' } );
+
 			// Make the selected region (and it only) active
 			$( '.regionselector' ).removeClass( 'active' );
 


### PR DESCRIPTION
his has been suggested on bug 39925 (https://bugzilla.wikimedia.org/show_bug.cgi?id=39925).

(The commits here include the ones on https://github.com/wikimedia/jquery.uls/pull/97 - it's a dependency since this probably won't work with lazyloading.)
