### PR TITLE
Only use default pos if top/left are undefined

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -149,8 +149,8 @@
 				height: this.$element[0].offsetHeight
 			} );
 			return {
-				top: this.top || pos.top + pos.height,
-				left: this.left || '25%'
+				top: this.top !== undefined ? this.top : pos.top + pos.height,
+				left: this.left !== undefined ? this.left : '25%'
 			};
 		},
 


### PR DESCRIPTION
Allows 0 (which is falsey) to be passed as an offsets. Fixes #141
