### PR TITLE
Hide misplaced borders in the compact design

### DIFF
--- a/css/jquery.uls.compact.css
+++ b/css/jquery.uls.compact.css
@@ -1,6 +1,7 @@
 .uls-compact .icon-close,
-.uls-compact .uls-title,
-.uls-compact .map-block {
+.uls-compact .uls-title-region,
+.uls-compact .map-block,
+.uls-compact #settings-block {
 	display: none !important;
 }
 


### PR DESCRIPTION
The border on top is white and therefore not visible. It's simply the wrong element hidden.

The border at the bottom was gray and visible. It looked like a misplaced 2px border.
