### PR TITLE
Restore destroyed search box design

### DIFF
--- a/css/jquery.uls.compact.css
+++ b/css/jquery.uls.compact.css
@@ -9,22 +9,7 @@
 }
 
 .uls-compact .search {
-	background: white;
 	border-top: none;
-	padding: 0.8em 0;
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
-	border-bottom-color: #DDD;
-}
-
-.uls-compact .filterinput,
-.uls-compact .filterinput:focus {
-	background-color: transparent;
-	border: none;
-	box-shadow: none;
-	outline: none;
-	font-size: 18px;
-	left: 0;
 }
 
 .uls-compact .uls-language-list {


### PR DESCRIPTION
This patch removes the obfuscation from the search box in the "Compact language links" feature and restores the original style of the feature as it was designed in the Universal Language Selector.

Simply removing all styles from an input field is confusing and inconsistent, especially if the same extension uses two completely different styles. A search box must look like a search box. That's nothing I make up: Check google.com and all other search engines and major websites, they are all using a clearly visible search box. If you want to change the design of this extension then please change the style in the original place, please.
