### PR TITLE
For narrow ULS show one column without separators

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -248,6 +248,7 @@
 		 */
 		listen: function () {
 			var lcd, columnsOptions,
+				languageCodes, i,
 				uls = this;
 
 			columnsOptions = {
@@ -295,27 +296,37 @@
 				onSelect: $.proxy( this.select, this )
 			} );
 
+
 			// Create region selectors, one per region
-			this.$menu.find( '.uls-region, .uls-region-link' ).regionselector( {
-				$target: lcd,
-				languages: this.languages,
-				success: function ( regionfilter ) {
-					// Deactivate search filtering
-					uls.$languageFilter.languagefilter( 'deactivate' );
-
-					// If it is the WW region, show the quicklist
-					if ( regionfilter.regionGroup === 1 ) {
-						lcd.quicklist();
-					}
-
-					// Show 'results view' if we are in no results mode
-					uls.success();
-				},
-				noresults: function () {
-					uls.$languageFilter.languagefilter( 'clear' );
+			if ( this.getMenuWidth() === 'narrow' ) {
+				// For narrow class ULS, there is no region filter
+				languageCodes = Object.keys( this.languages );
+				for ( i = 0; i < languageCodes.length; i++ ) {
+					lcd.append( languageCodes[ i ], 'WW' );
 				}
-			} );
+				// And do not show the map
+				this.$menu.find( '.uls-worldmap, .uls-region' ).remove();
+			} else {
+				this.$menu.find( '.uls-region, .uls-region-link' ).regionselector( {
+					$target: lcd,
+					languages: this.languages,
+					success: function ( regionfilter ) {
+						// Deactivate search filtering
+						uls.$languageFilter.languagefilter( 'deactivate' );
 
+						// If it is the WW region, show the quicklist
+						if ( regionfilter.regionGroup === 1 ) {
+							lcd.quicklist();
+						}
+
+						// Show 'results view' if we are in no results mode
+						uls.success();
+					},
+					noresults: function () {
+						uls.$languageFilter.languagefilter( 'clear' );
+					}
+				} );
+			}
 			$( 'html' ).click( $.proxy( this.cancel, this ) );
 		},
 

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -124,21 +124,25 @@
 			regions.push( this.buildQuicklist() );
 
 			$.each( $.uls.data.regiongroups, function ( regionCode ) {
+				var $regionTitle;
+
 				lcd.regionLanguages[regionCode] = [];
 				// Don't show the region unless it was enabled
 				if ( $.inArray( regionCode, lcd.options.showRegions ) === -1 ) {
 					return;
 				}
 
+				if ( lcd.options.columns > 1 ) {
+					// If there is only one column, Don't show region header
+					$regionTitle = $( '<h3>' )
+						.attr( 'data-i18n', 'uls-region-' + regionCode )
+						.addClass( 'eleven columns uls-lcd-region-title' )
+						.text( regionNames[regionCode] );
+				}
 				$section = $( '<div>' )
 					.addClass( 'eleven columns offset-by-one uls-lcd-region-section hide' )
 					.attr( 'id', regionCode )
-					.append(
-						$( '<h3>' )
-						.attr( 'data-i18n', 'uls-region-' + regionCode )
-						.addClass( 'eleven columns uls-lcd-region-title' )
-						.text( regionNames[regionCode] )
-					);
+					.append( $regionTitle );
 
 				regions.push( $section );
 			} );
@@ -216,7 +220,7 @@
 				if ( i === 0 ) {
 					currentScript = $.uls.data.getScriptGroupOfLanguage( languages[i] );
 				} else if ( currentScript !== nextScript && items.length > 1 ) {
-					force = true;
+					force = columnsPerRow === 1 ? false: true;
 				}
 				currentScript = nextScript;
 


### PR DESCRIPTION
For narrow ULS show one column without separators. And do not show the map.

If the number of languages is small, directly add them to lcd from uls.core.js. Add a condition to avoid showing the region titles.
