### PR TITLE
Restore support for IE8

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -354,10 +354,24 @@
 		 * @return string
 		 */
 		getMenuWidth: function () {
-			var languagesCount;
+			var language, languagesCount = 0;
 
 			if ( this.options.menuWidth ) {
 				return this.options.menuWidth;
+			}
+
+			// IE8 does not support Object.keys
+			if ( Object.keys ) {
+				languagesCount = Object.keys( this.options.languages ).length;
+			} else {
+				for ( language in this.options.languages ) {
+					if ( Object.prototype.hasOwnProperty.call(
+						this.options.languages,
+						language
+					) ) {
+						languagesCount++;
+					}
+				}
 			}
 
 			languagesCount = Object.keys( this.options.languages ).length;


### PR DESCRIPTION
IE8 does not support Object.keys.

https://phabricator.wikimedia.org/T86516

Copying the patch from Gerrit:
https://gerrit.wikimedia.org/r/#/c/184316/