### PR TITLE
Make magnifying glass icon clickable

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -34,7 +34,7 @@
 			</div>\
 			<div id="search" class="row uls-search"> \
 				<div class="one column">\
-					<span class="uls-search-label"></span>\
+					<label class="uls-search-label" for="uls-languagefilter"></label>\
 				</div>\
 				<div class="ten columns">\
 					<div id="uls-search-input-block" class="uls-search-input-block">\


### PR DESCRIPTION
This makes the magnifying glass icon (search.svg) clickable. Clicking focuses the input field next to the icon, which is the expected, helpful behaviour in my opinion. This is especially helpful with the "compact links" beta feature where the input box is completely invisible and the only remaining indicator that the user can type something is the blinking cursor. If the focus is lost for some reason, this patch allows the user to click the magnifying icon and re-focus the input field again.