### PR TITLE
Show the Common language section only if the list is long enough

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -53,16 +53,12 @@
 		</div>';
 	/*jshint multistr:false */
 
-	$.uls = $.uls || {};
-
-	$.uls.utils = {};
-
 	/**
 	 * Count the number of keys in an object.
 	 * Works in a cross-browser way.
 	 * @param {Object} The object.
 	 */
-	$.uls.utils.objectLength = function ( obj ) {
+	function objectLength ( obj ) {
 		var count, key;
 
 		// Some old browsers don't support Object.keys
@@ -236,7 +232,7 @@
 		 * Bind the UI elements with their event listeners
 		 */
 		listen: function () {
-			var lcd, columnsOptions,
+			var lcd, columnsOptions, languagesCount,
 				uls = this;
 
 			columnsOptions = {
@@ -263,10 +259,12 @@
 				this.$menu.on( 'keydown', $.proxy( this.keypress, this ) );
 			}
 
+			languagesCount = objectLength( this.options.languages );
 			lcd = this.$resultsView.lcd( {
 				languages: this.languages,
 				columns: columnsOptions[ this.getMenuWidth() ],
-				quickList: this.options.quickList,
+
+				quickList: languagesCount > 12 ? this.options.quickList : false,
 				clickhandler: $.proxy( this.select, this ),
 				source: this.$languageFilter,
 				showRegions: this.options.showRegions,
@@ -388,7 +386,7 @@
 				return this.options.menuWidth;
 			}
 
-			languagesCount = $.uls.utils.objectLength( this.options.languages );
+			languagesCount = objectLength( this.options.languages );
 
 			if ( languagesCount < 12 ) {
 				return 'narrow';

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -75,7 +75,7 @@
 		}
 
 		return count;
-	};
+	}
 
 	/**
 	 * ULS Public class definition

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -53,6 +53,34 @@
 		</div>';
 	/*jshint multistr:false */
 
+	$.uls = $.uls || {};
+
+	$.uls.utils = {};
+
+	/**
+	 * Count the number of keys in an object.
+	 * Works in a cross-browser way.
+	 * @param {Object} The object.
+	 */
+	$.uls.utils.objectLength = function ( obj ) {
+		var count, key;
+
+		// Some old browsers don't support Object.keys
+		if ( Object.keys ) {
+			return Object.keys( obj ).length;
+		}
+
+		count = 0;
+
+		for ( key in obj ) {
+			if ( Object.prototype.hasOwnProperty.call( obj, key ) ) {
+				count++;
+			}
+		}
+
+		return count;
+	};
+
 	/**
 	 * ULS Public class definition
 	 */
@@ -354,26 +382,13 @@
 		 * @return string
 		 */
 		getMenuWidth: function () {
-			var language,
-				languagesCount = 0;
+			var languagesCount;
 
 			if ( this.options.menuWidth ) {
 				return this.options.menuWidth;
 			}
 
-			// IE8 does not support Object.keys
-			if ( Object.keys ) {
-				languagesCount = Object.keys( this.options.languages ).length;
-			} else {
-				for ( language in this.options.languages ) {
-					if ( Object.prototype.hasOwnProperty.call(
-						this.options.languages,
-						language
-					) ) {
-						languagesCount++;
-					}
-				}
-			}
+			languagesCount = $.uls.utils.objectLength( this.options.languages );
 
 			if ( languagesCount < 12 ) {
 				return 'narrow';

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -115,7 +115,6 @@
 
 		render: function () {
 			var $section,
-				languagesCount,
 				lcd = this,
 				regions = [],
 				regionNames = {
@@ -130,12 +129,7 @@
 					PA: 'Pacific'
 				};
 
-			languagesCount = $.uls.utils.objectLength( this.options.languages );
-
-			// Show the Common languages section, unless the list is very short
-			if ( languagesCount > 12 ) {
-				regions.push( this.buildQuicklist() );
-			}
+			regions.push( this.buildQuicklist() );
 
 			$.each( $.uls.data.regiongroups, function ( regionCode ) {
 				lcd.regionLanguages[ regionCode ] = [];

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -115,8 +115,7 @@
 
 		render: function () {
 			var $section,
-				language,
-				languagesCount = 0,
+				languagesCount,
 				lcd = this,
 				regions = [],
 				regionNames = {
@@ -131,19 +130,7 @@
 					PA: 'Pacific'
 				};
 
-			// IE8 does not support Object.keys
-			if ( Object.keys ) {
-				languagesCount = Object.keys( this.options.languages ).length;
-			} else {
-				for ( language in this.options.languages ) {
-					if ( Object.prototype.hasOwnProperty.call(
-						this.options.languages,
-						language
-					) ) {
-						languagesCount++;
-					}
-				}
-			}
+			languagesCount = $.uls.utils.objectLength( this.options.languages );
 
 			// Show the Common languages section, unless the list is very short
 			if ( languagesCount > 12 ) {

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -115,6 +115,8 @@
 
 		render: function () {
 			var $section,
+				language,
+				languagesCount = 0,
 				lcd = this,
 				regions = [],
 				regionNames = {
@@ -129,7 +131,24 @@
 					PA: 'Pacific'
 				};
 
-			regions.push( this.buildQuicklist() );
+			// IE8 does not support Object.keys
+			if ( Object.keys ) {
+				languagesCount = Object.keys( this.options.languages ).length;
+			} else {
+				for ( language in this.options.languages ) {
+					if ( Object.prototype.hasOwnProperty.call(
+						this.options.languages,
+						language
+					) ) {
+						languagesCount++;
+					}
+				}
+			}
+
+			// Show the Common languages section, unless the list is very short
+			if ( languagesCount > 12 ) {
+				regions.push( this.buildQuicklist() );
+			}
 
 			$.each( $.uls.data.regiongroups, function ( regionCode ) {
 				lcd.regionLanguages[ regionCode ] = [];

--- a/test/jquery.uls.test.js
+++ b/test/jquery.uls.test.js
@@ -272,4 +272,25 @@
 		assert.ok( !$.uls.data.deleteLanguage( 'qqr' ), 'Deleting language qqr, which was never added, returns false.' );
 	} );
 
+	test( '-- $.uls.utils testing', 4, function ( assert ) {
+		var languages, saveObjectKeys;
+
+		languages = {
+			mn: 'монгол',
+			sah: 'саха',
+			udm: 'удмурт'
+		};
+
+		assert.strictEqual( $.uls.utils.objectLength( {} ), 0 );
+		assert.strictEqual( $.uls.utils.objectLength( languages ), 3 );
+
+		// Simulate a browser without Object.keys
+		saveObjectKeys = Object.keys;
+		Object.keys = undefined;
+
+		assert.strictEqual( $.uls.utils.objectLength( {} ), 0 );
+		assert.strictEqual( $.uls.utils.objectLength( languages ), 3 );
+
+		Object.keys = saveObjectKeys;
+	} );
 }( jQuery ) );

--- a/test/jquery.uls.test.js
+++ b/test/jquery.uls.test.js
@@ -271,26 +271,4 @@
 		assert.strictEqual( $.uls.data.languages['qqq'], undefined, 'Data about qqq is undefined after being deleted.' );
 		assert.ok( !$.uls.data.deleteLanguage( 'qqr' ), 'Deleting language qqr, which was never added, returns false.' );
 	} );
-
-	test( '-- $.uls.utils testing', 4, function ( assert ) {
-		var languages, saveObjectKeys;
-
-		languages = {
-			mn: 'монгол',
-			sah: 'саха',
-			udm: 'удмурт'
-		};
-
-		assert.strictEqual( $.uls.utils.objectLength( {} ), 0 );
-		assert.strictEqual( $.uls.utils.objectLength( languages ), 3 );
-
-		// Simulate a browser without Object.keys
-		saveObjectKeys = Object.keys;
-		Object.keys = undefined;
-
-		assert.strictEqual( $.uls.utils.objectLength( {} ), 0 );
-		assert.strictEqual( $.uls.utils.objectLength( languages ), 3 );
-
-		Object.keys = saveObjectKeys;
-	} );
 }( jQuery ) );


### PR DESCRIPTION
This is done in the context of https://phabricator.wikimedia.org/T76196 , but is useful also for the Compact language links feature and any other short list of languages.