### PR TITLE
Add 'sudo: false' to upgrade to new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+sudo: false


### PR DESCRIPTION
This is done according to
http://docs.travis-ci.com/user/migrating-from-legacy/

As far as I know we don't need sudo of any kind,
and the performance advantages listed there sound good.