### PR TITLE
Support language codes that are redirects

### DIFF
--- a/src/jquery.uls.data.utils.js
+++ b/src/jquery.uls.data.utils.js
@@ -245,21 +245,18 @@
 	 */
 	$.uls.data.getLanguagesByScriptGroup = function ( languages ) {
 		var languagesByScriptGroup = {},
-			language, codeToAdd, langScriptGroup;
+			language, resolvedRedirect, langScriptGroup;
 
 		for ( language in languages ) {
-			codeToAdd = $.uls.data.isRedirect( language ) || language;
+			resolvedRedirect = $.uls.data.isRedirect( language ) || language;
 
-			langScriptGroup = $.uls.data.getScriptGroupOfLanguage( codeToAdd );
+			langScriptGroup = $.uls.data.getScriptGroupOfLanguage( resolvedRedirect );
 
 			if ( !languagesByScriptGroup[langScriptGroup] ) {
 				languagesByScriptGroup[langScriptGroup] = [];
 			}
 
-			// Prevent duplicate adding of redirects
-			if ( $.inArray( codeToAdd, languagesByScriptGroup[langScriptGroup] ) === -1 ) {
-				languagesByScriptGroup[langScriptGroup].push( codeToAdd );
-			}
+			languagesByScriptGroup[langScriptGroup].push( language );
 		}
 
 		return languagesByScriptGroup;

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -66,13 +66,13 @@
 		 * Adds language to the language list.
 		 * @param {string} langCode
 		 * @param {string} [regionCode]
-		 * @return {bool} Whether the language was added.
+		 * @return {boolean} Whether the language was added.
 		 */
 		append: function ( langCode, regionCode ) {
 			var lcd = this,
 				i, regions;
 
-			if ( !this.options.languages[ langCode ] ) {
+			if ( !$.uls.data.languages[ langCode ] ) {
 				// Language is unknown or not in the list of languages for this context.
 				return false;
 			}

--- a/test/jquery.uls.test.js
+++ b/test/jquery.uls.test.js
@@ -227,8 +227,8 @@
 			'vro': 'Võro' // Target after alias
 		};
 		groupedLanguages = {
-			Latin: [ 'en', 'vro', 'sr-latn' ],
-			Cyrillic: [ 'ru', 'sr-cyrl' ]
+			Latin: [ 'en', 'fiu-vro', 'sr-latn', 'sr-el', 'vro' ],
+			Cyrillic: [ 'ru', 'sr', 'sr-cyrl' ]
 		};
 
 		assert.deepEqual( $.uls.data.getLanguagesByScriptGroup( languagesToGroup ), groupedLanguages,


### PR DESCRIPTION
Addressing issue #207

Such language codes were not listed in ULS language list.

Root cause was $.uls.data.getLanguagesByScriptGroup was returning
a map of script groups, which contained only resolved language codes.
And later in append method of jquery.uls.lcd.js, there is a check if
that language code is part of languages list passed as option to uls()
call. This test fails and the language code does not get added to display.

Change-Id: Iec914a9694a46eef5750ef3af7346d66e052ab77