### PR TITLE
Call onCancel from hide

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -189,6 +189,10 @@
 		hide: function () {
 			this.$menu.hide();
 			this.shown = false;
+
+			if ( this.options.onCancel ) {
+				this.options.onCancel.call( this );
+			}
 		},
 
 		/**
@@ -310,10 +314,6 @@
 			}
 
 			this.hide();
-
-			if ( this.options.onCancel ) {
-				this.options.onCancel.call( this );
-			}
 		},
 
 		keyup: function ( e ) {


### PR DESCRIPTION
See issue #215

The cancel, hide methods are still confusing, may be in some other patch
we need clean up this. A grep shows ULS use onCancel only with compact
language links.

Change-Id: I0e08d169952945237efce9108d51cb68c4a29ad5