### PR TITLE
Adjust styles and code to support custom list bullets

### DIFF
--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -18,20 +18,19 @@
 	margin: 0 0 1.5em;
 }
 
-.uls-language-list ul li {
-	cursor: pointer;
-	font-weight: normal;
-	overflow: hidden;
-	white-space: nowrap;
-
+.uls-language-list ul {
 	/*
-	 * Some languages have long names for various reasons and we still want
-	 * them to appear on one line.
-	 * To make it work correctly, the directionality must be set correctly
-	 * on the item level.
+	 * We don't want any visible bullets in this list. Not by default anyway.
+	 * Using very unspecific selector here to allow other classes to override.
+	 * Bug because overflow: hidden is incompatible with bullets, also render
+	 * the bullets inside the list in case there should be any.
 	 */
-	text-overflow: ellipsis;
+	list-style-image: none;
+	list-style-type: none;
+}
 
+.uls-language-list li {
+	cursor: pointer;
 	/*
 	 * The directionality (ltr/rtl) for each list item is set dynamically
 	 * as HTML attributes in JavaScript. Setting directionality also applies
@@ -44,12 +43,16 @@
 	text-align: left;
 
 	/*
-	 * We don't want any visible bullets in this list.
+	 * Some languages have long names for various reasons and we still want
+	 * them to appear on one line.
+	 * To make it work correctly, the directionality must be set correctly
+	 * on the item level.
 	 */
-	list-style-image: none;
-	list-style-type: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
+/* TODO: looks unused */
 .uls-language-list strong {
 	text-decoration: underline;
 }
@@ -60,6 +63,11 @@
 	color: #3366bb;
 	font-size: 14px;
 	line-height: 1.6em;
+	display: inline-block;
+	width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	vertical-align: middle;
 }
 
 .uls-language-block {

--- a/examples/decorator.html
+++ b/examples/decorator.html
@@ -21,11 +21,19 @@
 		$( document ).ready( function () {
 			$( '.uls-trigger' ).uls( {
 				languageDecorator: function ( $language, languageCode ) {
+					if ( languageCode.indexOf( 'm' ) >= 0 ) {
+						$language.parent().addClass( 'badge' );
+					}
 					$language.prop( 'href', '//' + languageCode + '.wikipedia.org' );
 				},
 			} );
 		} );
 	</script>
+	<style>
+		.badge {
+			list-style-type: square;
+		}
+	</style>
 </head>
 
 <body>

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -273,13 +273,14 @@
 			// Not using jQuery as this is performance hotspot
 			li = document.createElement( 'li' );
 			li.title = name;
-			li.lang = code;
-			li.dir = $.uls.data.getDir( code );
 			li.setAttribute( 'data-code', code );
 
 			a = document.createElement( 'a' );
 			a.appendChild( document.createTextNode( autonym ) );
 			a.className = 'autonym';
+			a.lang = code;
+			a.dir = $.uls.data.getDir( code );
+
 
 			li.appendChild( a );
 			if ( this.options.languageDecorator ) {


### PR DESCRIPTION
Tweak specificty of the rule that hides bullets so that it is easy
to override. Display bullets inside the item because otherwise they
get hidden because we set overflow: hidden.

Move dir and lang attributes from <li> to <a> so that the bullets
appear on the correct side for reverse directionality scripts.