### PR TITLE
Namespaced all CSS classes

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -37,7 +37,7 @@
 }
 
 /* Override the grid */
-.uls-medium.grid .row {
+.uls-medium.uls-grid .uls-row {
 	min-width: 300px;
 }
 
@@ -47,7 +47,7 @@
 }
 
 /* Override the grid */
-.uls-narrow.grid .row {
+.uls-narrow.uls-grid .uls-row {
 	min-width: 150px;
 }
 
@@ -114,7 +114,7 @@ div.uls-region {
 	border-bottom-color: #DDD;
 }
 
-.grid .uls-search {
+.uls-grid .uls-search {
 	padding-left: 0;
 }
 

--- a/css/jquery.uls.grid.css
+++ b/css/jquery.uls.grid.css
@@ -1,254 +1,254 @@
 /* Generated using Foundation http://foundation.zurb.com/docs/grid.php */
 /* Global Reset & Standards ---------------------- */
-.grid * {
+.uls-grid * {
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
 /* Misc ---------------------- */
-.grid .left {
+.uls-grid .uls-left {
 	float: left;
 }
 
-.grid .right {
+.uls-grid .uls-right {
 	float: right;
 }
 
-.grid .text-left {
+.uls-grid .uls-text-left {
 	text-align: left;
 }
 
-.grid .text-right {
+.uls-grid .uls-text-right {
 	text-align: right;
 }
 
-.grid .text-center {
+.uls-grid .uls-text-center {
 	text-align: center;
 }
 
-.grid .hide {
+.uls-grid .uls-hide {
 	display: none;
 }
 
-.grid .highlight {
+.uls-grid .uls-highlight {
 	background: #ffff99;
 }
 
 /* The Grid ---------------------- */
-.grid .row {
+.uls-grid .uls-row {
 	width: 100%;
 	max-width: none;
 	min-width: 600px;
 	margin: 0 auto;
 }
 
-.grid .row .row {
+.uls-grid .uls-row .uls-row {
 	width: auto;
 	max-width: none;
 	min-width: 0;
 	margin: 0 -5px;
 }
 
-.grid .row.collapse .column,
-.grid .row.collapse .columns {
+.uls-grid .uls-row.uls-collapse .uls-column,
+.uls-grid .uls-row.uls-collapse .uls-columns {
 	padding: 0;
 }
 
-.grid .row .row {
+.uls-grid .uls-row .uls-row {
 	width: auto;
 	max-width: none;
 	min-width: 0;
 	margin: 0 -5px;
 }
 
-.grid .row .row.collapse {
+.uls-grid .uls-row .uls-row.uls-collapse {
 	margin: 0;
 }
 
-.grid .column, .grid .columns {
+.uls-grid .uls-column, .uls-grid .uls-columns {
 	float: left;
 	min-height: 1px;
 	padding: 0 5px;
 	position: relative;
 }
 
-.grid .column.centered, .grid .columns.centered {
+.uls-grid .uls-column.uls-centered, .uls-grid .uls-columns.uls-centered {
 	float: none;
 	margin: 0 auto;
 }
 
-.grid .row .one {
+.uls-grid .uls-row .uls-one {
 	width: 8.333%;
 }
 
-.grid .row .two {
+.uls-grid .uls-row .uls-two {
 	width: 16.667%;
 }
 
-.grid .row .three {
+.uls-grid .uls-row .uls-three {
 	width: 25%;
 }
 
-.grid .row .four {
+.uls-grid .uls-row .uls-four {
 	width: 33.333%;
 }
 
-.grid .row .five {
+.uls-grid .uls-row .uls-five {
 	width: 41.667%;
 }
 
-.grid .row .six {
+.uls-grid .uls-row .uls-six {
 	width: 50%;
 }
 
-.grid .row .seven {
+.uls-grid .uls-row .uls-seven {
 	width: 58.333%;
 }
 
-.grid .row .eight {
+.uls-grid .uls-row .uls-eight {
 	width: 66.667%;
 }
 
-.grid .row .nine {
+.uls-grid .uls-row .uls-nine {
 	width: 75%;
 }
 
-.grid .row .ten {
+.uls-grid .uls-row .uls-ten {
 	width: 83.333%;
 }
 
-.grid .row .eleven {
+.uls-grid .uls-row .uls-eleven {
 	width: 91.667%;
 }
 
-.grid .row .twelve {
+.uls-grid .uls-row .uls-twelve {
 	width: 100%;
 }
 
-.grid .row .offset-by-one {
+.uls-grid .uls-row .uls-offset-by-one {
 	margin-left: 8.333%;
 }
 
-.grid .row .offset-by-two {
+.uls-grid .uls-row .uls-offset-by-two {
 	margin-left: 16.667%;
 }
 
-.grid .row .offset-by-three {
+.uls-grid .uls-row .uls-offset-by-three {
 	margin-left: 25%;
 }
 
-.grid .row .offset-by-four {
+.uls-grid .uls-row .uls-offset-by-four {
 	margin-left: 33.333%;
 }
 
-.grid .row .offset-by-five {
+.uls-grid .uls-row .uls-offset-by-five {
 	margin-left: 41.667%;
 }
 
-.grid .row .offset-by-six {
+.uls-grid .uls-row .uls-offset-by-six {
 	margin-left: 50%;
 }
 
-.grid .row .offset-by-seven {
+.uls-grid .uls-row .uls-offset-by-seven {
 	margin-left: 58.333%;
 }
 
-.grid .row .offset-by-eight {
+.uls-grid .uls-row .uls-offset-by-eight {
 	margin-left: 66.667%;
 }
 
-.grid .row .offset-by-nine {
+.uls-grid .uls-row .uls-offset-by-nine {
 	margin-left: 75%;
 }
 
-.grid .row .offset-by-ten {
+.uls-grid .uls-row .uls-offset-by-ten {
 	margin-left: 83.333%;
 }
 
-.grid .push-two {
+.uls-grid .uls-push-two {
 	left: 16.667%;
 }
 
-.grid .pull-two {
+.uls-grid .uls-pull-two {
 	right: 16.667%;
 }
 
-.grid .push-three {
+.uls-grid .uls-push-three {
 	left: 25%;
 }
 
-.grid .pull-three {
+.uls-grid .uls-pull-three {
 	right: 25%;
 }
 
-.grid .push-four {
+.uls-grid .uls-push-four {
 	left: 33.333%;
 }
 
-.grid .pull-four {
+.uls-grid .uls-pull-four {
 	right: 33.333%;
 }
 
-.grid .push-five {
+.uls-grid .uls-push-five {
 	left: 41.667%;
 }
 
-.grid .pull-five {
+.uls-grid .uls-pull-five {
 	right: 41.667%;
 }
 
-.grid .push-six {
+.uls-grid .uls-push-six {
 	left: 50%;
 }
 
-.grid .pull-six {
+.uls-grid .uls-pull-six {
 	right: 50%;
 }
 
-.grid .push-seven {
+.uls-grid .uls-push-seven {
 	left: 58.333%;
 }
 
-.grid .pull-seven {
+.uls-grid .uls-pull-seven {
 	right: 58.333%;
 }
 
-.grid .push-eight {
+.uls-grid .uls-push-eight {
 	left: 66.667%;
 }
 
-.grid .pull-eight {
+.uls-grid .uls-pull-eight {
 	right: 66.667%;
 }
 
-.grid .push-nine {
+.uls-grid .uls-push-nine {
 	left: 75%;
 }
 
-.grid .pull-nine {
+.uls-grid .uls-pull-nine {
 	right: 75%;
 }
 
-.grid .push-ten {
+.uls-grid .uls-push-ten {
 	left: 83.333%;
 }
 
-.grid .pull-ten {
+.uls-grid .uls-pull-ten {
 	right: 83.333%;
 }
 
 /* Nicolas Gallagher's micro clearfix */
-.grid .row {
+.uls-grid .uls-row {
 	*zoom: 1;
 }
 
-.grid .row:before, .grid .row:after {
+.uls-grid .uls-row:before, .uls-grid .uls-row:after {
 	content: "";
 	display: table;
 }
 
-.grid .row:after {
+.uls-grid .uls-row:after {
 	clear: both;
 }
 
@@ -263,53 +263,53 @@
  lines below to support arbitrary height, but know
  that IE7/8 do not support :nth-child.
  -------------------------------------------------- */
-.grid .block-grid {
+.uls-grid .uls-block-grid {
 	display: block;
 	overflow: hidden;
 	padding: 0;
 }
 
-.grid .block-grid > li {
+.uls-grid .uls-block-grid > li {
 	display: block;
 	height: auto;
 	float: left;
 }
 
-.grid .block-grid.two-up {
+.uls-grid .uls-block-grid.uls-two-up {
 	margin: 0 -15px;
 }
 
-.grid .block-grid.two-up > li {
+.uls-grid .uls-block-grid.uls-two-up > li {
 	width: 50%;
 	padding: 0 15px 15px;
 }
 
-/* .block-grid.two-up>li:nth-child(2n+1) {clear: left;} */
-.grid .block-grid.three-up {
+/* .uls-block-grid.uls-two-up>li:nth-child(2n+1) {clear: left;} */
+.uls-grid .uls-block-grid.uls-three-up {
 	margin: 0 -12px;
 }
 
-.grid .block-grid.three-up > li {
+.uls-grid .uls-block-grid.uls-three-up > li {
 	width: 33.33%;
 	padding: 0 12px 12px;
 }
 
-/* .block-grid.three-up>li:nth-child(3n+1) {clear: left;} */
-.grid .block-grid.four-up {
+/* .uls-block-grid.uls-three-up>li:nth-child(3n+1) {clear: left;} */
+.uls-grid .uls-block-grid.uls-four-up {
 	margin: 0 -10px;
 }
 
-.grid .block-grid.four-up > li {
+.uls-grid .uls-block-grid.uls-four-up > li {
 	width: 25%;
 	padding: 0 10px 10px;
 }
 
-/* .block-grid.four-up>li:nth-child(4n+1) {clear: left;} */
-.grid .block-grid.five-up {
+/* .uls-block-grid.four-up>li:nth-child(4n+1) {clear: left;} */
+.uls-grid .uls-block-grid.uls-five-up {
 	margin: 0 -8px;
 }
 
-.grid .block-grid.five-up > li {
+.uls-grid .uls-block-grid.uls-five-up > li {
 	width: 20%;
 	padding: 0 8px 8px;
 }

--- a/css/jquery.uls.mobile.css
+++ b/css/jquery.uls.mobile.css
@@ -27,288 +27,288 @@
 		float: left !important;
 	}
 
-	.uls-mobile .row {
+	.uls-mobile .uls-row {
 		width: auto;
 		min-width: 0;
 		margin-left: 0;
 		margin-right: 0;
 	}
 
-	.uls-mobile .column,
-	.uls-mobile .columns {
+	.uls-mobile .uls-column,
+	.uls-mobile .uls-columns {
 		width: auto !important;
 		float: none;
 	}
 
-	.uls-mobile .column:last-child,
-	.uls-mobile .columns:last-child {
+	.uls-mobile .uls-column:last-child,
+	.uls-mobile .uls-columns:last-child {
 		float: none;
 	}
 
-	.uls-mobile [class*="column"] + [class*="column"]:last-child {
+	.uls-mobile [class*="uls-column"] + [class*="uls-column"]:last-child {
 		float: none;
 	}
 
-	.uls-mobile .column:before,
-	.uls-mobile .uls-mobile .columns:before,
-	.uls-mobile .column:after,
-	.columns:after {
+	.uls-mobile .uls-column:before,
+	.uls-mobile .uls-mobile .uls-columns:before,
+	.uls-mobile .uls-column:after,
+	.uls-columns:after {
 		content: "";
 		display: table;
 	}
 
-	.uls-mobile .column:after,
-	.uls-mobile .columns:after {
+	.uls-mobile .uls-column:after,
+	.uls-mobile .uls-columns:after {
 		clear: both;
 	}
 
-	.uls-mobile .offset-by-one,
-	.uls-mobile .offset-by-two,
-	.uls-mobile .offset-by-three,
-	.uls-mobile .offset-by-four,
-	.uls-mobile .offset-by-five,
-	.uls-mobile .offset-by-six,
-	.uls-mobile .offset-by-seven,
-	.uls-mobile .offset-by-eight,
-	.uls-mobile .offset-by-nine,
-	.uls-mobile .offset-by-ten {
+	.uls-mobile .uls-offset-by-one,
+	.uls-mobile .uls-offset-by-two,
+	.uls-mobile .uls-offset-by-three,
+	.uls-mobile .uls-offset-by-four,
+	.uls-mobile .uls-offset-by-five,
+	.uls-mobile .uls-offset-by-six,
+	.uls-mobile .uls-offset-by-seven,
+	.uls-mobile .uls-offset-by-eight,
+	.uls-mobile .uls-offset-by-nine,
+	.uls-mobile .uls-offset-by-ten {
 		margin-left: 0 !important;
 	}
 
-	.uls-mobile .push-two,
-	.uls-mobile .push-three,
-	.uls-mobile .push-four,
-	.uls-mobile .push-five,
-	.uls-mobile .push-six,
-	.uls-mobile .push-seven,
-	.uls-mobile .push-eight,
-	.uls-mobile .push-nine,
-	.uls-mobile .push-ten {
+	.uls-mobile .uls-push-two,
+	.uls-mobile .uls-push-three,
+	.uls-mobile .uls-push-four,
+	.uls-mobile .uls-push-five,
+	.uls-mobile .uls-push-six,
+	.uls-mobile .uls-push-seven,
+	.uls-mobile .uls-push-eight,
+	.uls-mobile .uls-push-nine,
+	.uls-mobile .uls-push-ten {
 		left: auto;
 	}
 
-	.uls-mobile .pull-two,
-	.uls-mobile .pull-three,
-	.uls-mobile .pull-four,
-	.uls-mobile .pull-five,
-	.uls-mobile .pull-six,
-	.uls-mobile .pull-seven,
-	.uls-mobile .pull-eight,
-	.uls-mobile .pull-nine,
-	.uls-mobile .pull-ten {
+	.uls-mobile .uls-pull-two,
+	.uls-mobile .uls-pull-three,
+	.uls-mobile .uls-pull-four,
+	.uls-mobile .uls-pull-five,
+	.uls-mobile .uls-pull-six,
+	.uls-mobile .uls-pull-seven,
+	.uls-mobile .uls-pull-eight,
+	.uls-mobile .uls-pull-nine,
+	.uls-mobile .uls-pull-ten {
 		right: auto;
 	}
 
 	/* Mobile 4-column Grid */
-	.uls-mobile .row .mobile-one {
+	.uls-mobile .uls-row .uls-mobile-one {
 		width: 25% !important;
 		float: left;
 		padding: 0 4px;
 	}
 
-	.uls-mobile .row .mobile-one:last-child {
+	.uls-mobile .uls-row .uls-mobile-one:last-child {
 		float: right;
 	}
 
-	.uls-mobile .row.collapse .mobile-one {
+	.uls-mobile .uls-row.collapse .uls-mobile-one {
 		padding: 0;
 	}
 
-	.uls-mobile .row .mobile-two {
+	.uls-mobile .uls-row .uls-mobile-two {
 		width: 50% !important;
 		float: left;
 		padding: 0 4px;
 	}
 
-	.uls-mobile .row .mobile-two:last-child {
+	.uls-mobile .uls-row .uls-mobile-two:last-child {
 		float: right;
 	}
 
-	.uls-mobile .row.collapse .mobile-two {
+	.uls-mobile .uls-row.collapse .uls-mobile-two {
 		padding: 0;
 	}
 
-	.uls-mobile .row .mobile-three {
+	.uls-mobile .uls-row .uls-mobile-three {
 		width: 75% !important;
 		float: left;
 		padding: 0 4px;
 	}
 
-	.uls-mobile .row .mobile-three:last-child {
+	.uls-mobile .uls-row .uls-mobile-three:last-child {
 		float: right;
 	}
 
-	.uls-mobile .row.collapse .mobile-three {
+	.uls-mobile .uls-row.collapse .uls-mobile-three {
 		padding: 0;
 	}
 
-	.uls-mobile .row .mobile-four {
+	.uls-mobile .uls-row .uls-mobile-four {
 		width: 100% !important;
 		float: left;
 		padding: 0 4px;
 	}
 
-	.uls-mobile .row .mobile-four:last-child {
+	.uls-mobile .uls-row .uls-mobile-four:last-child {
 		float: right;
 	}
 
-	.uls-mobile .row.collapse .mobile-four {
+	.uls-mobile .uls-row.collapse .uls-mobile-four {
 		padding: 0;
 	}
 
-	.uls-mobile .push-one-mobile {
+	.uls-mobile .uls-push-one-mobile {
 		left: 25%;
 	}
 
-	.uls-mobile .pull-one-mobile {
+	.uls-mobile .uls-pull-one-mobile {
 		right: 25%;
 	}
 
-	.uls-mobile .push-two-mobile {
+	.uls-mobile .uls-push-two-mobile {
 		left: 50%;
 	}
 
-	.uls-mobile .pull-two-mobile {
+	.uls-mobile .uls-pull-two-mobile {
 		right: 50%;
 	}
 
-	.uls-mobile .push-three-mobile {
+	.uls-mobile .uls-push-three-mobile {
 		left: 75%;
 	}
 
-	.uls-mobile .pull-three-mobile {
+	.uls-mobile .uls-pull-three-mobile {
 		right: 75%;
 	}
 }
 
 /* Visibility Classes ---------------------- */
 /* Standard (large) display targeting */
-.uls-mobile .show-for-small,
-.uls-mobile .show-for-medium,
-.uls-mobile .show-for-medium-down,
-.uls-mobile .hide-for-large,
-.uls-mobile .hide-for-large-up,
-.uls-mobile .show-for-xlarge {
+.uls-mobile .uls-show-for-small,
+.uls-mobile .uls-show-for-medium,
+.uls-mobile .uls-show-for-medium-down,
+.uls-mobile .uls-hide-for-large,
+.uls-mobile .uls-hide-for-large-up,
+.uls-mobile .uls-show-for-xlarge {
 	display: none !important;
 }
 
-.uls-mobile .hide-for-xlarge,
-.uls-mobile .show-for-large,
-.uls-mobile .show-for-large-up,
-.uls-mobile .hide-for-small,
-.uls-mobile .hide-for-medium,
-.uls-mobile .hide-for-medium-down {
+.uls-mobile .uls-hide-for-xlarge,
+.uls-mobile .uls-show-for-large,
+.uls-mobile .uls-show-for-large-up,
+.uls-mobile .uls-hide-for-small,
+.uls-mobile .uls-hide-for-medium,
+.uls-mobile .uls-hide-for-medium-down {
 	display: block !important;
 }
 
 /* Very large display targeting */
 @media only screen and (min-width: 1441px) {
 
-	.uls-mobile .hide-for-small,
-	.uls-mobile .hide-for-medium,
-	.uls-mobile .hide-for-medium-down,
-	.hide-for-large, .show-for-large-up,
-	.show-for-xlarge {
+	.uls-mobile .uls-hide-for-small,
+	.uls-mobile .uls-hide-for-medium,
+	.uls-mobile .uls-hide-for-medium-down,
+	.uls-hide-for-large, .uls-show-for-large-up,
+	.uls-show-for-xlarge {
 		display: block !important;
 	}
 
-	.show-for-small,
-	.uls-mobile .show-for-medium,
-	.uls-mobile .show-for-medium-down,
-	.uls-mobile .show-for-large,
-	.uls-mobile .hide-for-large-up,
-	.uls-mobile .hide-for-xlarge {
+	.uls-show-for-small,
+	.uls-mobile .uls-show-for-medium,
+	.uls-mobile .uls-show-for-medium-down,
+	.uls-mobile .uls-show-for-large,
+	.uls-mobile .uls-hide-for-large-up,
+	.uls-mobile .uls-hide-for-xlarge {
 		display: none !important;
 	}
 }
 /* Medium display targeting */
 @media only screen and (max-width: 1279px) and (min-width: 768px) {
 
-	.uls-mobile .hide-for-small,
-	.uls-mobile .show-for-medium,
-	.uls-mobile .show-for-medium-down,
-	.uls-mobile .hide-for-large,
-	.uls-mobile .hide-for-large-up,
-	.uls-mobile .hide-for-xlarge {
+	.uls-mobile .uls-hide-for-small,
+	.uls-mobile .uls-show-for-medium,
+	.uls-mobile .uls-show-for-medium-down,
+	.uls-mobile .uls-hide-for-large,
+	.uls-mobile .uls-hide-for-large-up,
+	.uls-mobile .uls-hide-for-xlarge {
 		display: block !important;
 	}
 
-	.uls-mobile .show-for-small,
-	.uls-mobile .hide-for-medium,
-	.uls-mobile .hide-for-medium-down,
-	.uls-mobile .show-for-large,
-	.uls-mobile .show-for-large-up,
-	.uls-mobile .show-for-xlarge {
+	.uls-mobile .uls-show-for-small,
+	.uls-mobile .uls-hide-for-medium,
+	.uls-mobile .uls-hide-for-medium-down,
+	.uls-mobile .uls-show-for-large,
+	.uls-mobile .uls-show-for-large-up,
+	.uls-mobile .uls-show-for-xlarge {
 		display: none !important;
 	}
 }
 /* Small display targeting */
 @media only screen and (max-width: 767px) {
 
-	.uls-mobile .show-for-small,
-	.uls-mobile .hide-for-medium,
-	.uls-mobile .show-for-medium-down,
-	.uls-mobile .hide-for-large,
-	.uls-mobile .hide-for-large-up,
-	.uls-mobile .hide-for-xlarge {
+	.uls-mobile .uls-show-for-small,
+	.uls-mobile .uls-hide-for-medium,
+	.uls-mobile .uls-show-for-medium-down,
+	.uls-mobile .uls-hide-for-large,
+	.uls-mobile .uls-hide-for-large-up,
+	.uls-mobile .uls-hide-for-xlarge {
 		display: block !important;
 	}
-	.uls-mobile .hide-for-small,
-	.uls-mobile .show-for-medium,
-	.uls-mobile .hide-for-medium-down,
-	.uls-mobile .show-for-large,
-	.uls-mobile .show-for-large-up,
-	.uls-mobile .show-for-xlarge {
+	.uls-mobile .uls-hide-for-small,
+	.uls-mobile .uls-show-for-medium,
+	.uls-mobile .uls-hide-for-medium-down,
+	.uls-mobile .uls-show-for-large,
+	.uls-mobile .uls-show-for-large-up,
+	.uls-mobile .uls-show-for-xlarge {
 		display: none !important;
 	}
 }
 
 /* Orientation targeting */
-.uls-mobile .show-for-landscape,
-.uls-mobile .hide-for-portrait {
+.uls-mobile .uls-show-for-landscape,
+.uls-mobile .uls-hide-for-portrait {
 	display: block !important;
 }
 
-.uls-mobile .hide-for-landscape,
-.uls-mobile .show-for-portrait {
+.uls-mobile .uls-hide-for-landscape,
+.uls-mobile .uls-show-for-portrait {
 	display: none !important;
 }
 
 @media screen and (orientation: landscape) {
-	.uls-mobile .show-for-landscape,
-	.uls-mobile .hide-for-portrait {
+	.uls-mobile .uls-show-for-landscape,
+	.uls-mobile .uls-hide-for-portrait {
 		display: block !important;
 	}
-	.uls-mobile .hide-for-landscape,
-	.uls-mobile .show-for-portrait {
+	.uls-mobile .uls-hide-for-landscape,
+	.uls-mobile .uls-show-for-portrait {
 		display: none !important;
 	}
 }
 
 @media screen and (orientation: portrait) {
-	.uls-mobile .show-for-portrait,
-	.uls-mobile .hide-for-landscape {
+	.uls-mobile .uls-show-for-portrait,
+	.uls-mobile .uls-hide-for-landscape {
 		display: block !important;
 	}
-	.uls-mobile .hide-for-portrait,
-	.uls-mobile .show-for-landscape {
+	.uls-mobile .uls-hide-for-portrait,
+	.uls-mobile .uls-show-for-landscape {
 		display: none !important;
 	}
 }
 
 /* Touch-enabled device targeting */
-.uls-mobile .show-for-touch {
+.uls-mobile .uls-show-for-touch {
 	display: none !important;
 }
 
-.uls-mobile .hide-for-touch {
+.uls-mobile .uls-hide-for-touch {
 	display: block !important;
 }
 
-.uls-mobile .touch .show-for-touch {
+.uls-mobile .uls-touch .uls-show-for-touch {
 	display: block !important;
 }
 
-.uls-mobile .touch .hide-for-touch {
+.uls-mobile .uls-touch .uls-hide-for-touch {
 	display: none !important;
 }

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -25,8 +25,8 @@
 
 	// Region numbers in id attributes also appear in the langdb.
 	/*jshint multistr:true */
-	template = '<div class="grid uls-menu"> \
-			<div id="search" class="row uls-search"> \
+	template = '<div class="uls-grid uls-menu"> \
+			<div id="search" class="uls-row uls-search"> \
 				<div class="uls-search-wrapper"> \
 					<label class="uls-search-label" for="uls-languagefilter"></label>\
 					<div class="uls-search-input-wrapper">\
@@ -40,8 +40,8 @@
 					</div>\
 				</div>\
 			</div>\
-			<div class="row uls-language-list"></div>\
-			<div class="row" id="uls-settings-block"></div>\
+			<div class="uls-row uls-language-list"></div>\
+			<div class="uls-row" id="uls-settings-block"></div>\
 		</div>';
 	/*jshint multistr:false */
 

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -24,18 +24,18 @@
 
 	var noResultsTemplate, LanguageCategoryDisplay;
 
-	noResultsTemplate = $( '<div>' ).addClass( 'twelve columns uls-no-results-view hide' );
+	noResultsTemplate = $( '<div>' ).addClass( 'uls-twelve uls-columns uls-no-results-view uls-hide' );
 	noResultsTemplate.append(
 		$( '<h2>' )
 			.attr( 'data-i18n', 'uls-no-results-found' )
-			.addClass( 'eleven columns offset-by-one uls-no-results-found-title' )
+			.addClass( 'uls-eleven uls-columns uls-offset-by-one uls-no-results-found-title' )
 			.text( 'No results found' ),
 		$( '<div>' )
 			.attr( 'id', 'uls-no-found-more' )
 			.addClass( 'uls-no-found-more' )
 			.append(
 				$( '<div>' )
-					.addClass( 'ten columns offset-by-one' )
+					.addClass( 'uls-ten uls-columns uls-offset-by-one' )
 					.append(
 						$( '<p>' ).append(
 							$( '<span>' ).text( 'You can search by language name, script name, ISO code of language or you can browse by region.' )
@@ -47,7 +47,7 @@
 	LanguageCategoryDisplay = function ( element, options ) {
 		this.$element = $( element );
 		this.options = $.extend( {}, $.fn.lcd.defaults, options );
-		this.$element.addClass( 'lcd' );
+		this.$element.addClass( 'uls-lcd' );
 		this.regionLanguages = {};
 		this.renderTimeout = null;
 		this.cachedQuicklist = null;
@@ -140,14 +140,14 @@
 				}
 
 				$section = $( '<div>' )
-					.addClass( 'eleven columns offset-by-one uls-lcd-region-section hide' )
+					.addClass( 'uls-eleven uls-columns uls-offset-by-one uls-lcd-region-section uls-hide' )
 					.attr( 'id', regionCode );
 
 				// Show a region heading, unless we are using a narrow ULS
 				if ( lcd.options.columns !== 1 ) {
 					$section.append( $( '<h3>' )
 						.attr( 'data-i18n', 'uls-region-' + regionCode )
-						.addClass( 'eleven columns uls-lcd-region-title' )
+						.addClass( 'uls-eleven uls-columns uls-lcd-region-title' )
 						.text( regionNames[ regionCode ] )
 					);
 				}
@@ -167,7 +167,7 @@
 			var languages,
 				lcd = this;
 
-			this.$noResults.addClass( 'hide' );
+			this.$noResults.addClass( 'uls-hide' );
 			this.$element.find( '.uls-lcd-region-section' ).each( function () {
 				var $region = $( this ),
 					regionCode = $region.attr( 'id' );
@@ -180,7 +180,7 @@
 
 				languages = lcd.regionLanguages[ regionCode ];
 				if ( !languages || languages.length === 0 ) {
-					$region.addClass( 'hide' );
+					$region.addClass( 'uls-hide' );
 					return;
 				}
 
@@ -190,7 +190,7 @@
 					lcd.options.itemsPerColumn,
 					lcd.options.columns
 				);
-				$region.removeClass( 'hide' );
+				$region.removeClass( 'uls-hide' );
 
 				lcd.regionLanguages[ regionCode ] = [];
 			} );
@@ -212,11 +212,11 @@
 				rows = [];
 
 			if ( columnsPerRow === 1 ) {
-				columnsClasses = 'twelve columns';
+				columnsClasses = 'uls-twelve uls-columns';
 			} else if ( columnsPerRow === 2 ) {
-				columnsClasses = 'six columns';
+				columnsClasses = 'uls-six uls-columns';
 			} else {
-				columnsClasses = 'three columns';
+				columnsClasses = 'uls-three uls-columns';
 			}
 
 			if ( this.options.columns === 1 ) {
@@ -227,7 +227,7 @@
 				}
 
 				columns.push( $( '<ul>' ).addClass( columnsClasses ).append( items ) );
-				rows.push( $( '<div>' ).addClass( 'row uls-language-block' ).append( columns ) );
+				rows.push( $( '<div>' ).addClass( 'uls-row uls-language-block' ).append( columns ) );
 			} else {
 				// For medium and wide ULS, clever column placement
 				for ( i = 0; i < languagesCount; i++ ) {
@@ -249,7 +249,7 @@
 						columns.push( $( '<ul>' ).addClass( columnsClasses ).append( items ) );
 						items = [];
 						if ( columns.length >= columnsPerRow || lastItem ) {
-							rows.push( $( '<div>' ).addClass( 'row uls-language-block' ).append( columns ) );
+							rows.push( $( '<div>' ).addClass( 'uls-row uls-language-block' ).append( columns ) );
 							columns = [];
 						}
 					}
@@ -297,7 +297,7 @@
 		 * Adds quicklist as a region.
 		 */
 		quicklist: function () {
-			this.$element.find( '#uls-lcd-quicklist' ).removeClass( 'hide' );
+			this.$element.find( '#uls-lcd-quicklist' ).removeClass( 'uls-hide' );
 		},
 
 		buildQuicklist: function () {
@@ -322,12 +322,12 @@
 			quickList.sort( $.uls.data.sortByAutonym );
 
 			$quickListSection = $( '<div>' )
-				.addClass( 'eleven columns offset-by-one uls-lcd-region-section' )
+				.addClass( 'uls-eleven uls-columns uls-offset-by-one uls-lcd-region-section' )
 				.attr( 'id', 'uls-lcd-quicklist' );
 
 			$quickListSectionTitle = $( '<h3>' )
 				.attr( 'data-i18n', 'uls-common-languages' )
-				.addClass( 'eleven columns uls-lcd-region-title' )
+				.addClass( 'uls-eleven uls-columns uls-lcd-region-title' )
 				.text( 'Common languages' ); // This is placeholder text if jquery.i18n not present
 			$quickListSection.append( $quickListSectionTitle );
 
@@ -351,7 +351,7 @@
 		},
 
 		empty: function () {
-			this.$element.find( '#uls-lcd-quicklist' ).addClass( 'hide' );
+			this.$element.find( '#uls-lcd-quicklist' ).addClass( 'uls-hide' );
 		},
 
 		focus: function () {
@@ -359,7 +359,7 @@
 		},
 
 		noResults: function () {
-			this.$noResults.removeClass( 'hide' );
+			this.$noResults.removeClass( 'uls-hide' );
 			if ( this.$noResults.find( '.uls-lcd-region-title' ).length ) {
 				return;
 			}
@@ -376,7 +376,7 @@
 			var lcd = this;
 
 			if ( this.options.clickhandler ) {
-				this.$element.on( 'click', '.row li', function () {
+				this.$element.on( 'click', '.uls-row li', function () {
 					lcd.options.clickhandler.call( this, $( this ).data( 'code' ) );
 				} );
 			}


### PR DESCRIPTION
This PR updates *every* CSS class the plug-in uses to be namespaced with "uls-". This was most problematic with the grid classes, which are very likely to conflict with a project's established grid system. 