### PR TITLE
Rename common languages to suggested languages

### DIFF
--- a/i18n/en-gb.json
+++ b/i18n/en-gb.json
@@ -13,7 +13,7 @@
 	"uls-region-ME": "Middle East",
 	"uls-region-PA": "Pacific",
 	"uls-no-results-found": "No results found",
-	"uls-common-languages": "Common languages",
+	"uls-common-languages": "Suggested languages",
 	"uls-no-results-suggestion-title": "You may be interested in:",
 	"uls-search-help": "You can search by language name, script name, ISO code of language or you can browse by region.",
 	"uls-search-placeholder": "Language search"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,7 +14,7 @@
 	"uls-region-ME": "Middle East",
 	"uls-region-PA": "Pacific",
 	"uls-no-results-found": "No results found",
-	"uls-common-languages": "Common languages",
+	"uls-common-languages": "Suggested languages",
 	"uls-no-results-suggestion-title": "You may be interested in:",
 	"uls-search-help": "You can search by language name, script name, ISO code of language or you can browse by region.",
 	"uls-search-placeholder": "Language search"


### PR DESCRIPTION
Did not rename message key because new term is compatible.

I have updated qqq on translatewiki.net to cross-reference mobile
frontend message.

https://phabricator.wikimedia.org/T137867