### PR TITLE
Use an empty array for quickList everywhere, not false/null

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -260,7 +260,7 @@
 				languages: this.languages,
 				columns: columnsOptions[ this.getMenuWidth() ],
 
-				quickList: languagesCount > 12 ? this.options.quickList : false,
+				quickList: languagesCount > 12 ? this.options.quickList : [],
 				clickhandler: $.proxy( this.select, this ),
 				source: this.$languageFilter,
 				showRegions: this.options.showRegions,
@@ -397,7 +397,7 @@
 		onSelect: null, // Callback function to be called when a language is selected
 		searchAPI: null, // Language search API
 		languages: $.uls.data.getAutonyms(), // Languages to be used for ULS, default is all languages
-		quickList: null, // Array of language codes or function that returns such
+		quickList: [], // Array of language codes or function that returns such
 		// The options are wide (4 columns), medium (2 columns), and narrow (1 column).
 		// If not specified, it will be set automatically.
 		menuWidth: null,

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -412,7 +412,7 @@
 		// Other values will have rendering issues.
 		columns: 4,
 		languageDecorator: null,
-		quicklist: []
+		quickList: []
 	};
 
 	$.fn.lcd.Constructor = LanguageCategoryDisplay;


### PR DESCRIPTION
Also fix one type `quicklist` -> `quickList`, per @edg2s.

Follows cb85cda10e7b68af1009bc6e573cf7cc048ce943.

https://phabricator.wikimedia.org/T144871