### PR TITLE
Change "Language search" to "Search for a language"

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,5 +18,5 @@
 	"uls-common-languages": "Suggested languages",
 	"uls-no-results-suggestion-title": "You may be interested in:",
 	"uls-search-help": "You can search by language name, script name, ISO code of language or you can browse by region.",
-	"uls-search-placeholder": "Language search"
+	"uls-search-placeholder": "Search for a language"
 }

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -36,7 +36,7 @@
 						<input type="text" class="uls-filterinput uls-languagefilter"\
 							id="uls-languagefilter" data-clear="uls-languagefilter-clear"\
 							data-suggestion="uls-filtersuggestion"\
-							placeholder="Language search" autocomplete="off">\
+							placeholder="Search for a language" autocomplete="off">\
 					</div>\
 				</div>\
 			</div>\


### PR DESCRIPTION
Suggested at https://phabricator.wikimedia.org/T138235 .
This brings ULS closer to the mobile language search interface
in MediaWiki.