### PR TITLE
Using the message uls-search-help in the code

### DIFF
--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -35,6 +35,7 @@
 			.addClass( 'uls-no-found-more' )
 			.append(
 				$( '<div>' )
+					.attr( 'data-i18n', 'uls-search-help' )
 					.addClass( '' )
 					.append(
 						$( '<p>' ).append(


### PR DESCRIPTION
The translatable message uls-search-help was available in
the i18n files, but it was not actually used in the code,
so it was always shown in English.

This patch adds it to the JS code.