### PR TITLE
Make it possible to customize Territory-Language information

### DIFF
--- a/src/jquery.uls.data.utils.js
+++ b/src/jquery.uls.data.utils.js
@@ -267,6 +267,18 @@
 	};
 
 	/**
+	 * Adds languages to a territory.
+	 * Useful for customizing CLDR Territory-Language information,
+	 * although ideally it's better to make sure that it's correct
+	 * upstream in CLDR.
+	 * @param territory string Territory code
+	 * @return list of language codes
+	 */
+	$.uls.data.addLanguagesToTerritory = function ( territory, languages ) {
+		$.uls.data.territories[territory] = $.uls.data.territories[territory].concat( languages );
+	};
+
+	/**
 	 * Adds a language in run time and sets its options as provided.
 	 * If the target option is provided, the language is defined as a redirect.
 	 * Other possible options are script, regions and autonym.

--- a/test/jquery.uls.test.js
+++ b/test/jquery.uls.test.js
@@ -124,7 +124,7 @@
 		assert.ok( $.fn.uls, '$.fn.uls is defined' );
 	} );
 
-	test( '-- $.uls.data testing', 31, function ( assert ) {
+	test( '-- $.uls.data testing', 32, function ( assert ) {
 		var autonyms,
 			languagesToGroup, groupedLanguages;
 
@@ -217,6 +217,13 @@
 		assert.ok(
 			$.inArray( 'sah', $.uls.data.getLanguagesInTerritory( 'RU' ) ) > -1,
 			'Sakha language is spoken in Russia'
+		);
+
+		$.uls.data.addLanguagesToTerritory( 'BY', [ 'be-tarask' ] );
+
+		assert.ok(
+			$.inArray( 'be-tarask', $.uls.data.getLanguagesInTerritory( 'BY' ) ) > -1,
+			'Belarusian (Taraskevica) language is spoken in Belarus'
 		);
 
 		assert.ok( $.uls.data.deleteLanguage( 'qqq' ), 'Deleting language qqq, which was added earlier, returns true.' );


### PR DESCRIPTION
It sometimes happens that a language is spoken in a territory,
but isn't listed in the CLDR Territory-Language information.
This is particularly true for some languages in which there is a Wikipedia,
and aren't listed for any country in CLDR: be-tarask, nds-nl, and several others.