### PR TITLE
Drop `-webkit-linear-gradient` image CSS fallback

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -1,8 +1,5 @@
 .uls-trigger {
-	/* @embed */
 	background: url('../images/icon-language.png') no-repeat left center;
-	/* @embed */
-	background-image: -webkit-linear-gradient(transparent, transparent), url('../images/icon-language.svg');
 	/* @embed */
 	background-image: linear-gradient(transparent, transparent), url('../images/icon-language.svg');
 	padding-left: 30px;
@@ -69,7 +66,6 @@
 
 .uls-search-label {
 	background: url('../images/search.png') no-repeat center center;
-	background-image: -webkit-linear-gradient(transparent, transparent), url('../images/search.svg');
 	/* @embed */
 	background-image: linear-gradient(transparent, transparent), url('../images/search.svg');
 	background-size: 20px;
@@ -115,7 +111,6 @@
 
 .uls-languagefilter-clear {
 	background: url('../images/clear.png') no-repeat left center;
-	background-image: -webkit-linear-gradient(transparent, transparent), url('../images/clear.svg');
 	/* @embed */
 	background-image: linear-gradient(transparent, transparent), url('../images/clear.svg');
 	background-size: 15px;


### PR DESCRIPTION
This reduces the payload of CSS slightly (and in the few cases where these
were not just present but @embed'ed, significantly), at a cost of giving
those user agents which don't support the un-prefixed rule the icons as
PNGs rather than SVGs (i.e. Chrome < 25, Safari < 6.1, Android < 4.4).

We made this change for MediaWiki back in November 2015 in T118815. This
repo is not alone in not having noticed. :-)