### PR TITLE
Custom no-results message support

### DIFF
--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -102,6 +102,18 @@
 	vertical-align: middle;
 }
 
+.uls-no-results-view {
+	display: none;
+}
+
+.uls-lcd.uls-no-results > .uls-lcd-region-section {
+	display: none;
+}
+
+.uls-lcd.uls-no-results > .uls-no-results-view {
+	display: block;
+}
+
 .uls-no-results-found-title {
 	font-size: 16px;
 	padding: 0 16px 0 28px;

--- a/examples/index.html
+++ b/examples/index.html
@@ -20,7 +20,7 @@
 		<!-- demo -->
 		<link href="resources/demo.css" rel="stylesheet">
 		<!-- Libs -->
-		<script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
+		<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 		<!-- Source -->
 		<script src="../src/jquery.uls.data.js"></script>
 		<script src="../src/jquery.uls.data.utils.js"></script>
@@ -30,7 +30,7 @@
 		<script>
 			$( document ).ready( function() {
 				$( '.uls-trigger' ).uls( {
-					onSelect : function( language ) {
+					onSelect: function( language ) {
 						var languageName = $.uls.data.getAutonym( language );
 						$( '.uls-trigger' ).text( languageName );
 					},
@@ -42,12 +42,11 @@
 
 	<body>
 		<div class="navbar navbar-fixed-top">
-			<span class="active uls-trigger">Select Language</span>
+			<span class="active uls-trigger">Select language</span>
 			<h1>Universal Language Selector</h1>
 			<p>
-				Demonstration of jQuery plugin
+				Demonstration of jQuery.uls plugin
 			</p>
 		</div>
-		<div class="container"></div>
 	</body>
 </html>

--- a/examples/test-no-results.html
+++ b/examples/test-no-results.html
@@ -20,7 +20,7 @@
 		<!-- demo -->
 		<link href="resources/demo.css" rel="stylesheet">
 		<!-- Libs -->
-		<script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
+		<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
 		<!-- Source -->
 		<script src="../src/jquery.uls.data.js"></script>
 		<script src="../src/jquery.uls.data.utils.js"></script>
@@ -30,11 +30,13 @@
 		<script>
 			$( document ).ready( function() {
 				$( '.uls-trigger' ).uls( {
-					onSelect : function( language ) {
+					onSelect: function( language ) {
 						var languageName = $.uls.data.getAutonym( language );
 						$( '.uls-trigger' ).text( languageName );
 					},
-					noResultsTemplate: '<div>No article exist in the language you searched</div>'
+					noResultsTemplate: function( query ) {
+						return $( '<div>No article exists in the language ' + query + '</div>' )
+					}
 				} );
 			} );
 		</script>
@@ -42,12 +44,11 @@
 
 	<body>
 		<div class="navbar navbar-fixed-top">
-			<span class="active uls-trigger">Select Language</span>
+			<span class="active uls-trigger">Select language</span>
 			<h1>Universal Language Selector</h1>
 			<p>
-				Demonstration of jQuery plugin
+				Demonstration of jQuery.uls plugin
 			</p>
 		</div>
-		<div class="container"></div>
 	</body>
 </html>

--- a/examples/test-no-results.html
+++ b/examples/test-no-results.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="utf-8">
+
+		<!--
+		Always force latest IE rendering engine (even in intranet) & Chrome Frame
+		Remove this if you use the .htaccess
+		-->
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+		<title>Universal Language Selector</title>
+		<!-- <link rel="shortcut icon" href="/favicon.ico"> -->
+		<!-- <link rel="apple-touch-icon" href="/apple-touch-icon.png"> -->
+		<!-- <meta name="description" content=""> -->
+		<meta name="author" content="Santhosh Thottingal">
+		<link href="../css/jquery.uls.css" rel="stylesheet">
+		<link href="../css/jquery.uls.grid.css" rel="stylesheet">
+		<link href="../css/jquery.uls.lcd.css" rel="stylesheet">
+		<!-- demo -->
+		<link href="resources/demo.css" rel="stylesheet">
+		<!-- Libs -->
+		<script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
+		<!-- Source -->
+		<script src="../src/jquery.uls.data.js"></script>
+		<script src="../src/jquery.uls.data.utils.js"></script>
+		<script src="../src/jquery.uls.lcd.js"></script>
+		<script src="../src/jquery.uls.languagefilter.js"></script>
+		<script src="../src/jquery.uls.core.js"></script>
+		<script>
+			$( document ).ready( function() {
+				$( '.uls-trigger' ).uls( {
+					onSelect : function( language ) {
+						var languageName = $.uls.data.getAutonym( language );
+						$( '.uls-trigger' ).text( languageName );
+					},
+					noResultsTemplate: '<div>No article exist in the language you searched</div>'
+				} );
+			} );
+		</script>
+	</head>
+
+	<body>
+		<div class="navbar navbar-fixed-top">
+			<span class="active uls-trigger">Select Language</span>
+			<h1>Universal Language Selector</h1>
+			<p>
+				Demonstration of jQuery plugin
+			</p>
+		</div>
+		<div class="container"></div>
+	</body>
+</html>

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -191,13 +191,6 @@
 		},
 
 		/**
-		 * Callback for no results found context.
-		 */
-		noresults: function () {
-			this.$resultsView.lcd( 'noResults' );
-		},
-
-		/**
 		 * Callback for results found context.
 		 */
 		success: function () {
@@ -241,7 +234,8 @@
 				clickhandler: $.proxy( this.select, this ),
 				source: this.$languageFilter,
 				showRegions: this.options.showRegions,
-				languageDecorator: this.options.languageDecorator
+				languageDecorator: this.options.languageDecorator,
+				noResultsTemplate: this.options.noResultsTemplate
 			} ).data( 'lcd' );
 
 			this.$languageFilter.languagefilter( {
@@ -251,7 +245,7 @@
 				onSelect: $.proxy( this.select, this )
 			} );
 
-			this.$languageFilter.on( 'noresults.uls', $.proxy( this.noresults, this ) );
+			this.$languageFilter.on( 'noresults.uls', $.proxy( lcd.noResults, lcd ) );
 			this.$languageFilter.on( 'resultsfound.uls', $.proxy( this.success, this ) );
 
 			$( 'html' ).click( $.proxy( this.cancel, this ) );

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -22,30 +22,30 @@
 ( function ( $ ) {
 	'use strict';
 
-	var noResultsTemplate, LanguageCategoryDisplay;
+	// eslint-disable-next-line no-multi-str
+	var noResultsTemplate = '<div class="uls-no-results-view"> \
+		<h2 data-i18n="uls-no-results-found" class="uls-no-results-found-title">No results found</h2> \
+		<div class="uls-no-found-more"> \
+		<div><p> \
+		<span data-i18n="uls-search-help">You can search by language name, script name, ISO code of language or you can browse by region.</span>\
+		</p></div> \
+		</div></div>';
 
-	noResultsTemplate = $( '<div>' ).addClass( 'uls-no-results-view hide' );
-	noResultsTemplate.append(
-		$( '<h2>' )
-			.attr( 'data-i18n', 'uls-no-results-found' )
-			.addClass( 'uls-no-results-found-title' )
-			.text( 'No results found' ),
-		$( '<div>' )
-			.addClass( 'uls-no-found-more' )
-			.append(
-				$( '<div>' )
-					.addClass( '' )
-					.append(
-						$( '<p>' ).append(
-							$( '<span>' )
-								.attr( 'data-i18n', 'uls-search-help' )
-								.text( 'You can search by language name, script name, ISO code of language or you can browse by region.' )
-						)
-					)
-			)
-	);
-
-	LanguageCategoryDisplay = function ( element, options ) {
+	/**
+	 * Language category display
+	 * @param {Element} element The container element to which the languages to be displayed
+	 * @param {Object} [options] Configuration object
+	 * @cfg {Object} [languages] Languages known to the ULS. Keyed by language code, values are autonyms.
+	 * @cfg {string[]} [showRegions] Array of region codes to show. Default is
+	 *  [ 'WW', 'AM', 'EU', 'ME', 'AF', 'AS', 'PA' ],
+	 * @cfg {number} [itemsPerColumn] Number of languages per column.
+	 * @cfg {number} [columns] Number of columns for languages. Default is 4.
+	 * @cfg {function} [languageDecorator] Callback function to be called when a language
+	 *  link is prepared - for custom decoration.
+	 * @cfg {function|string[]} [quickList] The languages to display as suggestions for quick selectoin.
+	 * @cfg {string|jQuery} [noResultsTemplate]
+	 */
+	function LanguageCategoryDisplay( element, options ) {
 		this.$element = $( element );
 		this.options = $.extend( {}, $.fn.lcd.defaults, options );
 		this.$element.addClass( 'uls-lcd' );
@@ -53,12 +53,9 @@
 		this.renderTimeout = null;
 		this.cachedQuicklist = null;
 
-		this.$element.append( noResultsTemplate.clone() );
-		this.$noResults = this.$element.children( '.uls-no-results-view' );
-
 		this.render();
 		this.listen();
-	};
+	}
 
 	LanguageCategoryDisplay.prototype = {
 		constructor: LanguageCategoryDisplay,
@@ -163,6 +160,8 @@
 
 			lcd.$element.append( regions );
 
+			this.$element.append( $( this.options.noResultsTemplate ) );
+
 			this.i18n();
 		},
 
@@ -173,7 +172,7 @@
 			var languages,
 				lcd = this;
 
-			this.$noResults.addClass( 'hide' );
+			this.$element.removeClass( 'uls-no-results' );
 			this.$element.children( '.uls-lcd-region-section' ).each( function () {
 				var $region = $( this ),
 					regionCode = $region.data( 'region' );
@@ -363,22 +362,20 @@
 		},
 
 		noResults: function () {
-			var $suggestions;
-			this.$noResults.removeClass( 'hide' );
-			this.$noResults.siblings( '.uls-lcd-region-section' ).addClass( 'hide' );
+			var $suggestions, $noResults;
 
-			// Only build the data once
-			if ( this.$noResults.find( '.uls-lcd-region-title' ).length ) {
-				return;
-			}
+			this.$element.addClass( 'uls-no-results' );
+			$noResults = this.$element.children( '.uls-no-results-view' );
 
 			$suggestions = this.buildQuicklist().clone();
-			$suggestions.removeClass( 'hide' );
-			$suggestions.find( 'h3' )
+			$suggestions
+				.removeClass( 'hide' )
+				.find( 'h3' )
 				.data( 'i18n', 'uls-no-results-suggestion-title' )
 				.text( 'You may be interested in:' )
 				.i18n();
-			this.$noResults.find( 'h2' ).after( $suggestions );
+
+			$noResults.find( 'h2' ).after( $suggestions );
 		},
 
 		listen: function () {
@@ -416,8 +413,8 @@
 		// Other values will have rendering issues.
 		columns: 4,
 		languageDecorator: null,
-		quickList: []
+		quickList: [],
+		noResultsTemplate: noResultsTemplate
 	};
 
-	$.fn.lcd.Constructor = LanguageCategoryDisplay;
 }( jQuery ) );

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -44,7 +44,7 @@
 	 * @cfg {Function} [languageDecorator] Callback function to be called when a language
 	 *  link is prepared - for custom decoration.
 	 * @cfg {Function|string[]} [quickList] The languages to display as suggestions for quick selectoin.
-	 * @cfg {jQuery} [noResultsTemplate]
+	 * @cfg {jQuery|Function} [noResultsTemplate]
 	 */
 	function LanguageCategoryDisplay( element, options ) {
 		this.$element = $( element );
@@ -377,7 +377,7 @@
 
 			if ( typeof this.options.noResultsTemplate === 'function' ) {
 				$noResults =
-						this.options.noResultsTemplate.call( this, currentSearchQuery );
+					this.options.noResultsTemplate.call( this, currentSearchQuery );
 			} else if ( this.options.noResultsTemplate instanceof jQuery ) {
 				$noResults = this.options.noResultsTemplate;
 			} else {


### PR DESCRIPTION
* Refactoring and clean up for LanguageCategoryDisplay class
* Document the options for LanguageCategoryDisplay class
* Reduce the spreading of no results handler code
* Add an option to accept no results template
* Remove unwanted, unused constructor too
* Use CSS to hide or show the no-results view
* Remove the unwanted noresults method in jquery.uls.core, directly
  call the same method of lcd.
* Add an example

We might need some context also to the custom message such as the current query string. But we can revisit it when we really design some custom message for some use cases in mediawiki.
