### PR TITLE
Style adjustments for no-results

### DIFF
--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -121,13 +121,15 @@
 .uls-no-results-found-title {
 	font-size: 16px;
 	padding: 0 16px 0 28px;
+	margin: 20px 0;
 	border-bottom: 0;
-	color: #555;
+	color: #54595d;
 }
 
 .uls-no-found-more {
-	background: #f8f8f8;
-	padding: 0 16px 0 44px;
+	border-top: 1px solid #eaecf0;
+	color: #54595d;
+	padding: 12px 16px 12px 44px;
 	font-size: 0.9em;
 	width: 100%;
 	margin-top: 1.6em;

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -27,9 +27,7 @@
 		<h2 data-i18n="uls-no-results-found" class="uls-no-results-found-title">No results found</h2> \
 		<div class="uls-no-results-suggestions"></div> \
 		<div class="uls-no-found-more"> \
-		<div><p> \
-		<span data-i18n="uls-search-help">You can search by language name, script name, ISO code of language or you can browse by region.</span>\
-		</p></div> \
+		<div data-i18n="uls-search-help">You can search by language name, script name, ISO code of language or you can browse by region.</div> \
 		</div></div>';
 
 	/**


### PR DESCRIPTION
* 20px spacing above and below the "No results found" message.
* 12px spacing above and below the search indications ("You can search by...")
* Adjusting the text color to use Base20 (#54595D)
* Adjust the background to use the same background color as the area above it (#FCFCFC).
* Add a top border in Base80 (#EAECF0) to separate both areas.

See https://phabricator.wikimedia.org/T175235