### PR TITLE
Stop rendering languages twice on initial display

### DIFF
--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -186,7 +186,6 @@
 
 			if ( query === '' ) {
 				this.options.lcd.setGroupByRegionOverride( null );
-				languages.map( this.render.bind( this ) );
 				this.resultHandler( query, languages );
 				return;
 			}


### PR DESCRIPTION
The resultHandler is responsible for updating the `LanguageCategoryDisplay`, so we should not call `render` separately in `search` when there is no search query.

https://phabricator.wikimedia.org/T185086