### PR TITLE
Allow identifying the context of the different ULS panels within one app

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -54,6 +54,7 @@
 		this.$element = $( element );
 		this.options = $.extend( {}, $.fn.uls.defaults, options );
 		this.$menu = $( template );
+		this.$menu.data( 'uls-purpose', this.options.ulsPurpose );
 		this.languages = this.options.languages;
 
 		for ( code in this.languages ) {
@@ -393,6 +394,10 @@
 		// The options are wide (4 columns), medium (2 columns), and narrow (1 column).
 		// If not specified, it will be set automatically.
 		menuWidth: undefined,
+		// What is this ULS used for.
+		// Should be set for distinguishing between different instances of ULS
+		// in the same application.
+		ulsPurpose: '',
 		// Used by LCD
 		quickList: [],
 		// Used by LCD

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -54,7 +54,6 @@
 		this.$element = $( element );
 		this.options = $.extend( {}, $.fn.uls.defaults, options );
 		this.$menu = $( template );
-		this.$menu.data( 'uls-purpose', this.options.ulsPurpose );
 		this.languages = this.options.languages;
 
 		for ( code in this.languages ) {
@@ -231,6 +230,7 @@
 			this.$languageFilter.languagefilter( {
 				lcd: lcd,
 				languages: this.languages,
+				ulsPurpose: this.options.ulsPurpose,
 				searchAPI: this.options.searchAPI,
 				onSelect: $.proxy( this.select, this )
 			} );

--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -236,7 +236,7 @@
 				this.$element.trigger(
 					'noresults.uls',
 					query,
-					this.$element.parents( '.uls-menu' ).data( 'uls-purpose' )
+					this.options.ulsPurpose
 				);
 				return;
 			}
@@ -342,6 +342,10 @@
 		lcd: undefined,
 		// URL to which we append query parameter with the query value
 		searchAPI: undefined,
+		// What is this ULS used for.
+		// Should be set for distinguishing between different instances of ULS
+		// in the same application.
+		ulsPurpose: '',
 		// Object of language tags to language names
 		languages: [],
 		// Callback function when language is selected

--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -233,7 +233,11 @@
 		resultHandler: function ( query, results, autofillLabel ) {
 			if ( results.length === 0 ) {
 				this.$suggestion.val( '' );
-				this.$element.trigger( 'noresults.uls', query );
+				this.$element.trigger(
+					'noresults.uls',
+					query,
+					this.$element.parents( '.uls-menu' ).data( 'uls-purpose' )
+				);
 				return;
 			}
 


### PR DESCRIPTION
Add the ulsPurpose option. Empty string by default.

This is useful for web application that use ULS in several different context,
and need to distinguish what was the purpose of the particular ULS panel.

An example of usage can be found at
https://phabricator.wikimedia.org/T179402