### PR TITLE
Pass the event object when calling the click handler

### DIFF
--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -408,8 +408,8 @@
 			var lcd = this;
 
 			if ( this.options.clickhandler ) {
-				this.$element.on( 'click', '.row li', function () {
-					lcd.options.clickhandler.call( this, $( this ).data( 'code' ) );
+				this.$element.on( 'click', '.row li', function ( event ) {
+					lcd.options.clickhandler.call( this, $( this ).data( 'code' ), event );
 				} );
 			}
 		}


### PR DESCRIPTION
This will allow distinguishing Click and Ctrl/Command-Click.
See downstream bug https://phabricator.wikimedia.org/T189582