### PR TITLE
Send a data object in $.trigger

### DIFF
--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -235,8 +235,10 @@
 				this.$suggestion.val( '' );
 				this.$element.trigger(
 					'noresults.uls',
-					query,
-					this.options.ulsPurpose
+					{
+						query: query,
+						ulsPurpose: this.options.ulsPurpose
+					}
 				);
 				return;
 			}


### PR DESCRIPTION
There was a mistake in #299: the $.trigger() must take only one argument
for extraParameters. Sending another parameter causes NULL to be logged in
EventLogging for ulsPurpose.