### PR TITLE
Add maxlength to the languagefilter input

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -34,6 +34,7 @@
 						<input type="text" class="uls-filterinput uls-filtersuggestion"\
 							disabled="true" autocomplete="off">\
 						<input type="text" class="uls-filterinput uls-languagefilter"\
+							maxlength="40"\
 							data-clear="uls-languagefilter-clear"\
 							data-suggestion="uls-filtersuggestion"\
 							placeholder="Search for a language" autocomplete="off">\


### PR DESCRIPTION
This input field is only for language names. There's no reason for it
to have something longer. Looking at the logs of searches,
people sometimes write very long things there: gibberish,
URLs, inappropriate search strings, mistaken pastes from other places,
and so on.

So it should be limited by maxlength.

It's practically never useful after 20 characters, but setting at 40
just to be on the safe side. The longest language name in langdb is 34.