### PR TITLE
Fix onInputChange() handler being called twice

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -220,7 +220,7 @@
 				columns: columnsOptions[ this.menuWidth ],
 
 				quickList: languagesCount > 12 ? this.options.quickList : [],
-				clickhandler: $.proxy( this.select, this ),
+				clickhandler: this.select.bind( this ),
 				showRegions: this.options.showRegions,
 				languageDecorator: this.options.languageDecorator,
 				noResultsTemplate: this.options.noResultsTemplate,
@@ -233,10 +233,10 @@
 				languages: this.languages,
 				ulsPurpose: this.options.ulsPurpose,
 				searchAPI: this.options.searchAPI,
-				onSelect: $.proxy( this.select, this )
+				onSelect: this.select.bind( this )
 			} );
 
-			this.$languageFilter.on( 'noresults.uls', $.proxy( lcd.noResults, lcd ) );
+			this.$languageFilter.on( 'noresults.uls', lcd.noResults.bind( lcd ) );
 		},
 
 		recreateLanguageFilter: function () {
@@ -253,7 +253,7 @@
 		 */
 		listen: function () {
 			// Register all event listeners to the ULS here.
-			this.$element.on( 'click', $.proxy( this.click, this ) );
+			this.$element.on( 'click', this.click.bind( this ) );
 
 			// Don't do anything if pressing on empty space in the ULS
 			this.$menu.on( 'click', function ( e ) {
@@ -261,13 +261,13 @@
 			} );
 
 			// Handle key press events on the menu
-			this.$menu.on( 'keydown', $.proxy( this.keypress, this ) );
+			this.$menu.on( 'keydown', this.keypress.bind( this ) );
 
 			this.createLanguageFilter();
 
-			this.$languageFilter.on( 'resultsfound.uls', $.proxy( this.success, this ) );
+			this.$languageFilter.on( 'resultsfound.uls', this.success.bind( this ) );
 
-			$( 'html' ).click( $.proxy( this.cancel, this ) );
+			$( 'html' ).click( this.cancel.bind( this ) );
 			$( window ).resize( $.fn.uls.debounce( this.resize.bind( this ), 250 ) );
 		},
 

--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -59,10 +59,7 @@
 
 		listen: function () {
 			this.$element.on( 'keydown', this.keypress.bind( this ) );
-			this.$element.on(
-				'change textInput input',
-				$.fn.uls.debounce( this.onInputChange.bind( this ), 300 )
-			);
+			this.$element.on( 'input', $.fn.uls.debounce( this.onInputChange.bind( this ), 300 ) );
 
 			if ( this.$clear.length ) {
 				this.$clear.on( 'click', this.clear.bind( this ) );

--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -58,14 +58,14 @@
 		},
 
 		listen: function () {
-			this.$element.on( 'keydown', $.proxy( this.keypress, this ) );
+			this.$element.on( 'keydown', this.keypress.bind( this ) );
 			this.$element.on(
 				'change textInput input',
-				$.fn.uls.debounce( $.proxy( this.onInputChange, this ), 300 )
+				$.fn.uls.debounce( this.onInputChange.bind( this ), 300 )
 			);
 
 			if ( this.$clear.length ) {
-				this.$clear.on( 'click', $.proxy( this.clear, this ) );
+				this.$clear.on( 'click', this.clear.bind( this ) );
 			}
 
 			this.toggleClear();


### PR DESCRIPTION
ULS input element had onInputChange() handler attached to 'change', 'textInput' and 'input' events.

That caused onInputChange() to be called twice when there is user input and ULS gets closed, since 'change' event fires when <input type="text"> element loses focus.

Registering handler only for 'input' is sufficient for the intent.