### PR TITLE
Fixes for fetch-language-data.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /node_modules
 /dist
 data/supplementalData.xml
+/scripts/vendor
 /vendor
 .eslintcache

--- a/scripts/fetch-language-data.sh
+++ b/scripts/fetch-language-data.sh
@@ -2,8 +2,8 @@
 
 set -o errexit -o nounset -o pipefail
 
-readlinkf() { perl -MCwd -e 'print Cwd::abs_path shift;' "$1"; }
-BASEDIR=$(dirname "$(dirname "$(readlinkf "$0")")")
+scriptdir() { perl -MCwd -e 'print Cwd::abs_path shift;' "$1"; }
+BASEDIR=$(dirname "$(dirname "$(scriptdir "$0")")")
 DEST="$BASEDIR/src"
 CLONEDIR="$BASEDIR/vendor/language-data"
 UPSTREAM="https://github.com/wikimedia/language-data.git"

--- a/scripts/fetch-language-data.sh
+++ b/scripts/fetch-language-data.sh
@@ -2,8 +2,9 @@
 
 set -o errexit -o nounset -o pipefail
 
-BASEDIR=$(dirname "$(dirname "$(readlink -f "$0")")")
-DEST="$BASEDIR/src/"
+readlinkf() { perl -MCwd -e 'print Cwd::abs_path shift;' "$1"; }
+BASEDIR=$(dirname "$(dirname "$(readlinkf "$0")")")
+DEST="$BASEDIR/src"
 CLONEDIR="$BASEDIR/vendor/language-data"
 UPSTREAM="https://github.com/wikimedia/language-data.git"
 
@@ -30,4 +31,4 @@ echo "Transforming language-data"
 
 "$BASEDIR"/node_modules/browserify/bin/cmd.js "$CLONEDIR"/data/language-data.json -t "$BASEDIR"/scripts/transform.js -o "$DEST"/jquery.uls.data.js
 
-echo "language-data wrote to $DEST/jquery.uls.data.js"
+echo "language-data written to $DEST/jquery.uls.data.js"

--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -3283,7 +3283,7 @@ module.exports=( function ( $ ) {
             [
                 "EU"
             ],
-            "Кӣллт са̄мь кӣлл"
+            "кӣллт са̄мь кӣлл"
         ],
         "sje": [
             "Latn",
@@ -4851,7 +4851,6 @@ module.exports=( function ( $ ) {
             "id",
             "jv",
             "su",
-            "ms-arab",
             "ms",
             "min",
             "bew",
@@ -4859,6 +4858,7 @@ module.exports=( function ( $ ) {
             "bug",
             "bjn",
             "ace",
+            "ms-arab",
             "bbc-latn",
             "zh-hant",
             "zh",


### PR DESCRIPTION
* Portable path function, instead of `readlink -f`, which doesn't
  work on mac.
* Remove extra '/' character from DEST. It is added again later.
* Change "wrote" to "written" — clearer meaning of what was done.