### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -123,7 +123,7 @@ module.exports=( function ( $ ) {
                 "EU",
                 "AS"
             ],
-            "тÿштÿк алтай"
+            "алтай тил"
         ],
         "am": [
             "Ethi",
@@ -265,7 +265,7 @@ module.exports=( function ( $ ) {
                 "EU",
                 "AS"
             ],
-            "тÿндÿк алтай"
+            "тÿндÿк алтай тил"
         ],
         "av": [
             "Cyrl",
@@ -619,12 +619,15 @@ module.exports=( function ( $ ) {
             ],
             "Kaqchikel"
         ],
-        "cbk-zam": [
+        "cbk": [
             "Latn",
             [
                 "AS"
             ],
             "Chavacano de Zamboanga"
+        ],
+        "cbk-zam": [
+            "cbk"
         ],
         "ccp": [
             "Cakm",
@@ -4508,8 +4511,8 @@ module.exports=( function ( $ ) {
             "it",
             "ja",
             "es",
-            "ko",
             "kgp",
+            "ko",
             "yrl"
         ],
         "BS": [


### PR DESCRIPTION
Changes:
* Update autonyms for Altay languages (alt, atv)
* Add redirect from cbk-zam to cbk.
  (Addresses downstream bug https://phabricator.wikimedia.org/T263717 .)

Updating to
https://github.com/wikimedia/language-data/commit/51685b542b325d181b163451f8cf6a8404d54a9b