### PR TITLE
Always send event when triggering onSelect

### DIFF
--- a/src/jquery.uls.languagefilter.js
+++ b/src/jquery.uls.languagefilter.js
@@ -107,11 +107,11 @@
 
 					if ( this.selectedLanguage ) {
 						// this.selectLanguage will be populated from a matching search
-						this.options.onSelect( this.selectedLanguage );
+						this.options.onSelect( this.selectedLanguage, e );
 					} else if ( this.options.languages[ query ] ) {
 						// Search is yet to happen (in timeout delay),
 						// but we have a matching language code.
-						this.options.onSelect( query );
+						this.options.onSelect( query, e );
 					}
 
 					break;


### PR DESCRIPTION
The $.uls function in jquery.uls.core in createLanguageFilter
passes the onSelect function to the
$.fn.languagefilter so the onSelect there should be made
compatible.

Bug: T261973