### PR TITLE
Remove explicit width statements from ULS menu widths

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -21,12 +21,10 @@
 
 .uls-wide {
 	min-width: 715px;
-	width: 45%;
 }
 
 .uls-medium {
 	min-width: 360px;
-	width: 30%;
 }
 
 /* Override the grid */
@@ -36,7 +34,6 @@
 
 .uls-narrow {
 	min-width: 180px;
-	width: 20%;
 }
 
 /* Override the grid */


### PR DESCRIPTION
These seem to be more harmful than useful. On small screen the menu width gets too narrow, and on large screens the menu width gets too wide. The min-widths are sufficient.

Related to https://phabricator.wikimedia.org/T276255