### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -1470,6 +1470,13 @@
             ],
             "Gaelg"
         ],
+        "ha": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Hausa"
+        ],
         "ha-arab": [
             "Arab",
             [
@@ -1478,14 +1485,7 @@
             "هَوُسَ"
         ],
         "ha-latn": [
-            "Latn",
-            [
-                "AF"
-            ],
-            "Hausa"
-        ],
-        "ha": [
-            "ha-latn"
+            "ha"
         ],
         "hai": [
             "Latn",
@@ -4750,7 +4750,7 @@
             "ar",
             "ksf",
             "ha-arab",
-            "ha-latn"
+            "ha"
         ],
         "CN": [
             "zh",
@@ -5016,7 +5016,7 @@
             "ee",
             "gur",
             "gaa",
-            "ha-latn",
+            "ha",
             "ff"
         ],
         "GI": [
@@ -5515,7 +5515,7 @@
             "fr"
         ],
         "NE": [
-            "ha-latn",
+            "ha",
             "fr",
             "ar",
             "ff"
@@ -5525,7 +5525,7 @@
         ],
         "NG": [
             "en",
-            "ha-latn",
+            "ha",
             "ig",
             "yo",
             "ha-arab",
@@ -5768,7 +5768,7 @@
             "ar",
             "en",
             "ha-arab",
-            "ha-latn"
+            "ha"
         ],
         "SE": [
             "sv",


### PR DESCRIPTION
Make 'ha' the primary code for Hausa
instead of ha-latn.

Updating to:
https://github.com/wikimedia/language-data/commit/d56debb089c61c019c77b1c63dc37ae2cf198791