### PR TITLE
ULS LCD: Check if region exists before adding languages

### DIFF
--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -98,7 +98,9 @@
 			}
 
 			for ( i = 0; i < regions.length; i++ ) {
-				this.regionLanguages[ regions[ i ] ].push( langCode );
+				if ( this.regionLanguages[ regions[ i ] ] ) {
+					this.regionLanguages[ regions[ i ] ].push( langCode );
+				}
 			}
 
 			// Work around the bad interface, delay rendering until we have got


### PR DESCRIPTION
The regions displayed on ULS depend on the showRegions parameter
passed to uls.lcd plugin. If a new language and region have
been added to the language data, the region for it will not be
available to showRegion because it's static.

Bug: https://phabricator.wikimedia.org/T187553