### PR TITLE
Change font-size unit from px to em

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -76,7 +76,7 @@
 
 /* There are two input boxes. This class applies to both of them */
 .uls-filterinput {
-	font-size: 16px;
+	font-size: 1.2em;
 	height: 32px;
 	width: 100%;
 	/* For the custom clear (X) icon */

--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -76,7 +76,7 @@
 
 /* There are two input boxes. This class applies to both of them */
 .uls-filterinput {
-	font-size: 1.2em;
+	font-size: 1.143em;
 	height: 32px;
 	width: 100%;
 	/* For the custom clear (X) icon */

--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -19,7 +19,7 @@
 
 .uls-lcd-region-title {
 	color: #555;
-	font-size: 14px;
+	font-size: 1em;
 	padding-left: 28px;
 }
 
@@ -91,7 +91,7 @@
 	cursor: pointer;
 	text-decoration: none;
 	color: #36c;
-	font-size: 14px;
+	font-size: 1em;
 	display: inline-block;
 	width: 100%;
 	overflow-x: hidden;
@@ -119,7 +119,7 @@
 }
 
 .uls-no-results-found-title {
-	font-size: 16px;
+	font-size: 1.2em;
 	padding: 0 16px 0 28px;
 	margin: 20px 0;
 	border-bottom: 0;

--- a/css/jquery.uls.lcd.css
+++ b/css/jquery.uls.lcd.css
@@ -119,7 +119,7 @@
 }
 
 .uls-no-results-found-title {
-	font-size: 1.2em;
+	font-size: 1.143em;
 	padding: 0 16px 0 28px;
 	margin: 20px 0;
 	border-bottom: 0;
@@ -133,7 +133,7 @@
 	font-size: 0.9em;
 	width: 100%;
 	margin-top: 1.6em;
-	line-height: 1.6em;
+	line-height: 1.6;
 	position: absolute;
 	bottom: 0;
 	left: 0;

--- a/css/jquery.uls.mobile.css
+++ b/css/jquery.uls.mobile.css
@@ -18,7 +18,7 @@
 	}
 
 	.uls-mobile .uls-language-block a {
-		font-size: 16px;
+		font-size: 1.2em;
 		line-height: 1.7em;
 	}
 

--- a/css/jquery.uls.mobile.css
+++ b/css/jquery.uls.mobile.css
@@ -18,7 +18,7 @@
 	}
 
 	.uls-mobile .uls-language-block a {
-		font-size: 1.2em;
+		font-size: 1.143em;
 		line-height: 1.7em;
 	}
 


### PR DESCRIPTION
The convention to avoid px in font-size and use em instead was
added to Wikimedia coding conventions was added in December 2020:
https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS#Don't_rely_on_px_unit_based_values

Now it's also enforced using stylelint.

This commit changes all CSS font-size values that were still in px
to em units.