### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -2158,8 +2158,7 @@
         "krj": [
             "Latn",
             [
-                "ME",
-                "EU"
+                "AS"
             ],
             "Kinaray-a"
         ],
@@ -3010,7 +3009,6 @@
         "olo": [
             "Latn",
             [
-                "AS",
                 "EU"
             ],
             "livvinkarjala"
@@ -3485,7 +3483,7 @@
             [
                 "AF"
             ],
-            "Kinyarwanda"
+            "Ikinyarwanda"
         ],
         "rwr": [
             "Deva",
@@ -3495,11 +3493,11 @@
             "मारवाड़ी"
         ],
         "ryu": [
-            "Kana",
+            "Jpan",
             [
                 "AS"
             ],
-            "ʔucināguci"
+            "うちなーぐち"
         ],
         "sa": [
             "Deva",
@@ -4122,7 +4120,7 @@
             [
                 "AS"
             ],
-            "Kokborok (Tripuri)"
+            "Kokborok"
         ],
         "tru": [
             "Latn",
@@ -4437,12 +4435,7 @@
             "SaiSiyat"
         ],
         "ydd": [
-            "Hebr",
-            [
-                "AS",
-                "EU"
-            ],
-            "Eastern Yiddish"
+            "yi"
         ],
         "yi": [
             "Hebr",
@@ -4659,7 +4652,6 @@
             "Hani",
             "Hans",
             "Hant",
-            "Kana",
             "Kore",
             "Jpan",
             "Yiii"


### PR DESCRIPTION
* Fix location for Karay-a (krj) and Livvi-Karelian (olo)
* Fix autonyms for Kinyarwanda (rw), Okinawan (ryu),
  and Kokborok (trp)
* Remove Eastern Yiddish (ydd), which is practically
  identical to Yiddish (yi).
* Remove "Kana" as a separate writing systems, and merge it with "Jpan".

Updating to
https://github.com/wikimedia/language-data/commit/35f37b6c5fa14881bb9e107edc3d52c20272636e