### PR TITLE
Update language-data

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -3875,6 +3875,13 @@
             ],
             "Sranantongo"
         ],
+        "sro": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "sardu campidanesu"
+        ],
         "ss": [
             "Latn",
             [
@@ -5786,6 +5793,7 @@
             "ha-arab",
             "kcg",
             "ar",
+            "ann",
             "ff"
         ],
         "NI": [
@@ -6014,7 +6022,8 @@
             "ar"
         ],
         "SB": [
-            "en"
+            "en",
+            "pis"
         ],
         "SC": [
             "fr",


### PR DESCRIPTION
* Add Campidanese Sardinian (sro)
* Auto-update territory info: add Obolo (ann) to Nigeria
  and Pijin (pis) to Solomon Islands.

Updating to
https://github.com/wikimedia/language-data/commit/627d49561e9d1728c2a82d09a4be40a665231c9a