### PR TITLE
Auto-update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3596,9 +3596,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -8261,9 +8261,9 @@
 			"dev": true
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"


### PR DESCRIPTION
Done using `npm audit fix`.

Bumps minimatch version to 3.0.8.