### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -1623,7 +1623,7 @@
                 "AM",
                 "PA"
             ],
-            "Hawai`i"
+            "Hawaiʻi"
         ],
         "he": [
             "Hebr",
@@ -1799,6 +1799,13 @@
                 "AF"
             ],
             "Igbo"
+        ],
+        "igl": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Igala"
         ],
         "ii": [
             "Yiii",


### PR DESCRIPTION
* Use turned comma in the autonym of Hawaii (haw)
* Add Igala (igl)

Updating to
https://github.com/wikimedia/language-data/commit/f95b5fe6758d5d9a1d899392e39bc6c6ff4c45f1