### PR TITLE
Remove padding from .uls-filterinput

### DIFF
--- a/css/jquery.uls.css
+++ b/css/jquery.uls.css
@@ -79,8 +79,6 @@
 	font-size: 1.143em;
 	height: 32px;
 	width: 100%;
-	/* For the custom clear (X) icon */
-	padding: 6px 25px 6px 0;
 	outline: 0;
 	border: 0;
 	display: block;


### PR DESCRIPTION
Padding hid the search placeholder making it appear cropped.

Bug: [T318633](https://phabricator.wikimedia.org/T318633)