### PR TITLE
jquery.uls.lcd: Check if languages are present before highlighting

### DIFF
--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -148,6 +148,10 @@
 		 */
 		highlightLanguageOption: function () {
 			var $listItems = this.getLanguageOptionListItems();
+			// There are no language items. Nothing to highlight.
+			if ( !$listItems.length ) {
+				return;
+			}
 			$listItems.removeClass( 'uls-language-option--highlighted' );
 
 			var $selectedItem = $listItems.eq( this.navigationIndex );


### PR DESCRIPTION
There might not be any languages if uls empty state is set in ULS extension

Bug: https://phabricator.wikimedia.org/T328956