### PR TITLE
Conditionally render search placeholder text

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,5 +18,6 @@
 	"uls-common-languages": "Suggested languages",
 	"uls-no-results-suggestion-title": "You may be interested in:",
 	"uls-search-help": "You can search by language name, script name, ISO code of language or you can browse by region.",
-	"uls-search-placeholder": "Search for a language"
+	"uls-search-placeholder": "Search for a language",
+	"uls-search-placeholder-short": "Search"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -20,5 +20,5 @@
 	"uls-no-results-suggestion-title": "Title for language suggestion in 'no results found' screen",
 	"uls-search-help": "Help text for searching.\n\n\"Script name\" is a name of a writing system, such as \"Latin\", \"Cyrillic\", \"Arabic\" etc.",
 	"uls-search-placeholder": "Placeholder text in search box",
-	"uls-search-placeholder-short": "Shorter placeholder text in search box"
+	"uls-search-placeholder-short": "Shorter placeholder text in search box when menu width is narrow"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -19,5 +19,6 @@
 	"uls-common-languages": "The ULS tries to guess the langugages that the user is most likely to pick. They are taken from geolocation (languages of the current country according to the IP address), previously selected languages, and the browser's accept-language. The list of these languages appears at the top of the ULS languages list, above the geographical regions. This is the title of that list.\n\nSee also {{msg-mw|Mobile-frontend-languages-structured-overlay-suggested-languages-header}}",
 	"uls-no-results-suggestion-title": "Title for language suggestion in 'no results found' screen",
 	"uls-search-help": "Help text for searching.\n\n\"Script name\" is a name of a writing system, such as \"Latin\", \"Cyrillic\", \"Arabic\" etc.",
-	"uls-search-placeholder": "Placeholder text in search box"
+	"uls-search-placeholder": "Placeholder text in search box",
+	"uls-search-placeholder-short": "Shorter placeholder text in search box"
 }

--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -174,7 +174,11 @@
 		i18n: function () {
 			if ( $.i18n ) {
 				this.$menu.find( '[data-i18n]' ).i18n();
-				this.$languageFilter.prop( 'placeholder', $.i18n( 'uls-search-placeholder' ) );
+				if ( this.getMenuWidth() === 'narrow' ) {
+					this.$languageFilter.prop( 'placeholder', $.i18n( 'uls-search-placeholder-short' ) );
+				} else {
+					this.$languageFilter.prop( 'placeholder', $.i18n( 'uls-search-placeholder' ) );
+				}
 			}
 		},
 


### PR DESCRIPTION
Placeholder text was appearing cropped in menuWidth = 'narrow' 
This commit serves to conditionally render placeholder text to a shorter 'Search'

Bug: https://phabricator.wikimedia.org/T318633