### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -954,6 +954,13 @@
         "crh-latn": [
             "crh"
         ],
+        "crh-ro": [
+            "Latn",
+            [
+                "EU"
+            ],
+            "tatarşa"
+        ],
         "cs": [
             "Latn",
             [


### PR DESCRIPTION
Add Crimen Tatar (Romania).

Updating to
https://github.com/wikimedia/language-data/commit/d8b9138988d0abaadb0a40fa1d158a3fa3a4aa7d