### PR TITLE
Focus ULS button when the language menu is closed with Escape

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -328,6 +328,7 @@
 
 			if ( e.keyCode === 27 ) { // escape
 				this.cancel();
+				this.$element.focus();
 				e.preventDefault();
 				e.stopPropagation();
 			}


### PR DESCRIPTION
Before this, the focus would return to the `<body>` element (i.e. at the very top of the document) when you hit the Escape key, instead of the ULS button, so if you were navigating with the keyboard, you would have to tab through all preceding focusable elements before you got back to the language button (and beyond).

Bug: [T325009](https://phabricator.wikimedia.org/T325009)