### PR TITLE
Hide language redirects in the ULS panel

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -590,6 +590,13 @@
             ],
             "हरियाणवी"
         ],
+        "bgc-arab": [
+            "Arab",
+            [
+                "AS"
+            ],
+            "ہریانوی"
+        ],
         "bgn": [
             "Arab",
             [
@@ -2255,6 +2262,13 @@
             ],
             "Karai-karai"
         ],
+        "kaj": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Jju"
+        ],
         "kam": [
             "Latn",
             [
@@ -2780,6 +2794,13 @@
                 "AS"
             ],
             "ລາວ"
+        ],
+        "lou": [
+            "Latn",
+            [
+                "AM"
+            ],
+            "Kouri-Vini"
         ],
         "loz": [
             "Latn",
@@ -4701,7 +4722,7 @@
             [
                 "AF"
             ],
-            "ትግረ"
+            "ትግሬ"
         ],
         "tji": [
             "Latn",
@@ -5378,6 +5399,14 @@
         "zh-yue": [
             "yue"
         ],
+        "zmi": [
+            "Latn",
+            [
+                "AS",
+                "PA"
+            ],
+            "Nismilan"
+        ],
         "zsm": [
             "ms"
         ],
@@ -5806,8 +5835,8 @@
         "CN": [
             "zh",
             "wuu",
-            "yue-hans",
             "yue",
+            "yue-hans",
             "hsn",
             "hak",
             "nan",
@@ -6043,6 +6072,7 @@
             "gu",
             "sco",
             "cy",
+            "ro",
             "bn",
             "ar",
             "zh-hant",
@@ -6577,6 +6607,7 @@
             "ta",
             "iba",
             "jv",
+            "zmi",
             "dtp",
             "ml",
             "bug",
@@ -6622,6 +6653,7 @@
             "ibb",
             "ha-arab",
             "bin",
+            "kaj",
             "kcg",
             "ar",
             "ann"

--- a/src/jquery.uls.lcd.js
+++ b/src/jquery.uls.lcd.js
@@ -210,6 +210,11 @@
 				return false;
 			}
 
+			if ( $.uls.data.isRedirect( langCode ) ) {
+				// Make sure we do not add redirects
+				return false;
+			}
+
 			if ( !this.isGroupingByRegionEnabled() ) {
 				regions = [ 'all' ];
 


### PR DESCRIPTION
Around 30 languages with redirects and variants appear twice in the ULS panel. This fix checks if a redirect exists for a language code, and if it does, it updates the target in the languages object and removes the redirect.

Bug: [T195342](https://phabricator.wikimedia.org/T195342)