### PR TITLE
Update language-data from upstream

### DIFF
--- a/src/jquery.uls.data.js
+++ b/src/jquery.uls.data.js
@@ -62,6 +62,13 @@
             ],
             "Kwéyòl Sent Lisi"
         ],
+        "ach": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Acoli"
+        ],
         "acm": [
             "Arab",
             [
@@ -2390,7 +2397,7 @@
                 "AS",
                 "PA"
             ],
-            "Basa Kumoring"
+            "Kumoring"
         ],
         "kge-arab": [
             "Arab",
@@ -2398,7 +2405,7 @@
                 "AS",
                 "PA"
             ],
-            "باس كوموريڠ"
+            "كوموريڠ"
         ],
         "kgp": [
             "Latn",
@@ -2729,6 +2736,13 @@
                 "AF"
             ],
             "Kilaangi"
+        ],
+        "laj": [
+            "Latn",
+            [
+                "AF"
+            ],
+            "Lëblaŋo"
         ],
         "lb": [
             "Latn",
@@ -3103,18 +3117,21 @@
             "mvf"
         ],
         "mnc": [
+            "Latn",
+            [
+                "AS"
+            ],
+            "manju gisun"
+        ],
+        "mnc-latn": [
+            "mnc"
+        ],
+        "mnc-mong": [
             "Mong",
             [
                 "AS"
             ],
             "ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ"
-        ],
-        "mnc-latn": [
-            "Latn",
-            [
-                "AS"
-            ],
-            "Manju gisun"
         ],
         "mni": [
             "Mtei",
@@ -3129,6 +3146,14 @@
                 "AS"
             ],
             "মেইতেই লোন্"
+        ],
+        "mns": [
+            "Cyrl",
+            [
+                "EU",
+                "AS"
+            ],
+            "ма̄ньси"
         ],
         "mnw": [
             "Mymr",
@@ -7180,6 +7205,8 @@
             "lg",
             "nyn",
             "en",
+            "laj",
+            "ach",
             "rw",
             "ttj",
             "hi"


### PR DESCRIPTION
Add:
* Acholi (ach)
* Lango (laj)
* Mansi (mns)

Update autonym:
* Komering (kge, kge-arab)

Also set up Manchu (mnc) as:
* mnc (in practice Latin script)
* mnc-latn (redirect to mnc)
* mnc-mong (Mongolian/Manchu script) This may be changed later, but for now,
this is the situtation in core MediaWiki,
so working with that.

Updating to
https://github.com/wikimedia/language-data/commit/5fee9a371c2e40ff6bdce22595929d76bbdaafc3